### PR TITLE
Migrate TelnyxSharp off RestSharp onto HttpClient; net10; TUnit tests; standard CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - alpha
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v5
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
+    - name: Restore
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+
+    - name: Test
+      run: dotnet test --project TelnyxSharp.Tests/TelnyxSharp.Tests.csproj -c Release --no-build
+      env:
+        DOTNET_CLI_TELEMETRY_OPTOUT: true
+        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+        DOTNET_NOLOGO: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
 
     - name: Set Branch-Specific Variables
       id: branch_vars
@@ -33,13 +33,14 @@ jobs:
         dotnet restore
         dotnet build --configuration Release --no-restore
 
-#    - name: Test
-#      run: |
-#        dotnet test TelnyxSharp.Tests/TelnyxSharp.Tests.csproj
-#      env:
-#        DOTNET_CLI_TELEMETRY_OPTOUT: true
-#        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-#        DOTNET_NOLOGO: true
+    - name: Test
+      run: |
+        dotnet test --project TelnyxSharp.Tests/TelnyxSharp.Tests.csproj -c Release
+      env:
+        TELNYX_API_KEY: ${{ secrets.TELNYX_API_KEY }}
+        DOTNET_CLI_TELEMETRY_OPTOUT: true
+        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+        DOTNET_NOLOGO: true
 
     - name: Pack
       run: |

--- a/TelnyxSharp.Components.BlazorWebRTC/TelnyxSharp.Components.BlazorWebRTC.csproj
+++ b/TelnyxSharp.Components.BlazorWebRTC/TelnyxSharp.Components.BlazorWebRTC.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>false</IsPackable>
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
         <PackageReference Include="MudBlazor" Version="8.6.0" />
     </ItemGroup>
 

--- a/TelnyxSharp.Tests/CdrRequestsOperationsTests.cs
+++ b/TelnyxSharp.Tests/CdrRequestsOperationsTests.cs
@@ -1,13 +1,19 @@
 ﻿using TelnyxSharp.Enums;
 using TelnyxSharp.V1Operations.Models.Requests;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
 namespace TelnyxSharp.Tests;
 
-public class CdrRequestsOperationsTests : TelnyxTestBase
+public sealed class CdrRequestsOperationsTests : TelnyxTestBase
 {
 
-    [Fact]
+    [Test]
     public async Task FullCdrRequestLifecycle_Succeeds()
     {
+        SkipIfNotIntegrationTest();
+
         var id = await CreateCdrRequestAsync();
 
         try
@@ -23,14 +29,16 @@ public class CdrRequestsOperationsTests : TelnyxTestBase
         }
     }
 
-    [Fact]
+    [Test]
     public async Task Create_WithMinimalFields_Succeeds()
     {
+        SkipIfNotIntegrationTest();
+
         var id = await CreateCdrRequestAsync();
 
         try
         {
-            Assert.False(string.IsNullOrEmpty(id));
+            await Assert.That(string.IsNullOrEmpty(id)).IsFalse();
         }
         finally
         {
@@ -38,9 +46,11 @@ public class CdrRequestsOperationsTests : TelnyxTestBase
         }
     }
 
-    [Fact]
+    [Test]
     public async Task List_ReturnsCreatedRequest()
     {
+        SkipIfNotIntegrationTest();
+
         var id = await CreateCdrRequestAsync();
 
         try
@@ -53,9 +63,11 @@ public class CdrRequestsOperationsTests : TelnyxTestBase
         }
     }
 
-    [Fact]
+    [Test]
     public async Task Get_ExistingCdrRequest_ReturnsCorrectData()
     {
+        SkipIfNotIntegrationTest();
+
         var id = await CreateCdrRequestAsync();
 
         try
@@ -68,9 +80,11 @@ public class CdrRequestsOperationsTests : TelnyxTestBase
         }
     }
 
-    [Fact]
+    [Test]
     public async Task Delete_ExistingCdrRequest_Succeeds()
     {
+        SkipIfNotIntegrationTest();
+
         var id = await CreateCdrRequestAsync();
         await DeleteCdrRequestAsync(id);
         // No need for cleanup as we just deleted it
@@ -94,8 +108,8 @@ public class CdrRequestsOperationsTests : TelnyxTestBase
             .CdrRequests
             .Create(req, CancellationToken.None);
 
-        Assert.NotNull(resp);
-        Assert.False(string.IsNullOrEmpty(resp.Id));
+        await Assert.That(resp).IsNotNull();
+        await Assert.That(string.IsNullOrEmpty(resp.Id)).IsFalse();
         return resp.Id;
     }
 
@@ -107,8 +121,8 @@ public class CdrRequestsOperationsTests : TelnyxTestBase
             .CdrRequests
             .List(req, CancellationToken.None);
 
-        Assert.NotNull(list);
-        Assert.Contains(list, r => r.Id == expectedId);
+        await Assert.That(list).IsNotNull();
+        await Assert.That(list.Any(r => r.Id == expectedId)).IsTrue();
     }
 
     private async Task GetCdrRequestAsync(string id)
@@ -118,8 +132,8 @@ public class CdrRequestsOperationsTests : TelnyxTestBase
             .CdrRequests
             .Get(id, CancellationToken.None);
 
-        Assert.NotNull(resp);
-        Assert.Equal(id, resp.Id);
+        await Assert.That(resp).IsNotNull();
+        await Assert.That(resp.Id).IsEqualTo(id);
     }
 
     private async Task DeleteCdrRequestAsync(string id)
@@ -129,8 +143,8 @@ public class CdrRequestsOperationsTests : TelnyxTestBase
             .CdrRequests
             .Delete(id, CancellationToken.None);
 
-        Assert.NotNull(resp);
-        Assert.True(resp.Success, $"Expected deletion of CDR Request {id} to succeed, but got: {resp.Message}");
+        await Assert.That(resp).IsNotNull();
+        await Assert.That(resp.Success).IsTrue();
     }
 
     private async Task CleanupCdrRequestAsync(string id)
@@ -148,8 +162,4 @@ public class CdrRequestsOperationsTests : TelnyxTestBase
         }
     }
 
-    public void Dispose()
-    {
-        Client.Dispose();
-    }
 }

--- a/TelnyxSharp.Tests/DetailRecordsOperationsTests.cs
+++ b/TelnyxSharp.Tests/DetailRecordsOperationsTests.cs
@@ -1,13 +1,18 @@
-﻿using TelnyxSharp.DetailRecords.Models.Requests;
+using TelnyxSharp.DetailRecords.Models.Requests;
 using TelnyxSharp.DetailRecords.Models.Responses;
 using TelnyxSharp.Enums;
 using TelnyxSharp.Tests;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
 
-public class DetailRecordsOperationsTests : TelnyxTestBase
+public sealed class DetailRecordsOperationsTests : TelnyxTestBase
 {
-    [Fact]
+    [Test]
     public async Task Search_WithMinimalParams_ReturnsResults()
     {
+        SkipIfNotIntegrationTest();
+
         // Arrange
         var request = new DetailRecordSearchRequest
         {
@@ -19,26 +24,29 @@ public class DetailRecordsOperationsTests : TelnyxTestBase
         var response = await Client.DetailRecordsSearch.Search(request);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotEmpty(response.Data);
-        Assert.NotNull(response.Meta);
-        Assert.InRange(response.Meta.PageNumber, 1, int.MaxValue);
-        Assert.InRange(response.Meta.PageSize, 1, 50);
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response.Data).IsNotEmpty();
+        await Assert.That(response.Meta).IsNotNull();
+        await Assert.That(response.Meta.PageNumber).IsGreaterThanOrEqualTo(1);
+        await Assert.That(response.Meta.PageSize).IsBetween(1, 50);
 
-        Assert.All(response.Data, record =>
+        foreach (var record in response.Data)
         {
-            var msg = Assert.IsType<MessageDetailRecord>(record);
-            Assert.NotNull(msg.Uuid);
-            Assert.NotNull(msg.Status);
-            Assert.NotNull(msg.Cld);
-            Assert.NotNull(msg.Cli);
-            Assert.NotEqual(default, msg.CreatedAt);
-        });
+            await Assert.That(record).IsTypeOf<MessageDetailRecord>();
+            var msg = (MessageDetailRecord)record;
+            await Assert.That(msg.Uuid).IsNotNull();
+            await Assert.That(msg.Status).IsNotNull();
+            await Assert.That(msg.Cld).IsNotNull();
+            await Assert.That(msg.Cli).IsNotNull();
+            await Assert.That(msg.CreatedAt).IsNotEqualTo(default);
+        }
     }
 
-    [Fact]
+    [Test]
     public async Task Search_WithFilters_ReturnsFilteredResults()
     {
+        SkipIfNotIntegrationTest();
+
         // Arrange
         var startTime = DateTime.UtcNow.AddDays(-1);
         var request = new DetailRecordSearchRequest
@@ -66,18 +74,21 @@ public class DetailRecordsOperationsTests : TelnyxTestBase
         var response = await Client.DetailRecordsSearch.Search(request);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.All(response.Data, record =>
+        await Assert.That(response).IsNotNull();
+        foreach (var record in response.Data)
         {
-            var msg = Assert.IsType<MessageDetailRecord>(record);
-            Assert.Equal("delivered", msg.Status);
-            Assert.True(msg.CreatedAt >= startTime);
-        });
+            await Assert.That(record).IsTypeOf<MessageDetailRecord>();
+            var msg = (MessageDetailRecord)record;
+            await Assert.That(msg.Status).IsEqualTo("delivered");
+            await Assert.That(msg.CreatedAt >= startTime).IsTrue();
+        }
     }
 
-    [Fact]
+    [Test]
     public async Task Search_WithPagination_WorksCorrectly()
     {
+        SkipIfNotIntegrationTest();
+
         // Arrange
         var firstPageRequest = new DetailRecordSearchRequest
         {
@@ -97,18 +108,18 @@ public class DetailRecordsOperationsTests : TelnyxTestBase
         var firstPage = await Client.DetailRecordsSearch.Search(firstPageRequest);
         var secondPage = await Client.DetailRecordsSearch.Search(secondPageRequest);
 
-        Assert.NotNull(firstPage);
-        Assert.NotNull(secondPage);
-        Assert.NotEmpty(firstPage.Data);
-        Assert.NotEmpty(secondPage.Data);
-        
-        Assert.Equal(1, firstPage.Meta.PageNumber);
-        Assert.Equal(2, secondPage.Meta.PageNumber);
-        Assert.Equal(5, firstPage.Meta.PageSize);
-        Assert.Equal(5, secondPage.Meta.PageSize);
+        await Assert.That(firstPage).IsNotNull();
+        await Assert.That(secondPage).IsNotNull();
+        await Assert.That(firstPage.Data).IsNotEmpty();
+        await Assert.That(secondPage.Data).IsNotEmpty();
+
+        await Assert.That(firstPage.Meta.PageNumber).IsEqualTo(1);
+        await Assert.That(secondPage.Meta.PageNumber).IsEqualTo(2);
+        await Assert.That(firstPage.Meta.PageSize).IsEqualTo(5);
+        await Assert.That(secondPage.Meta.PageSize).IsEqualTo(5);
 
         var firstPageIds = firstPage.Data.Cast<MessageDetailRecord>().Select(d => d.Uuid);
         var secondPageIds = secondPage.Data.Cast<MessageDetailRecord>().Select(d => d.Uuid);
-        Assert.Empty(firstPageIds.Intersect(secondPageIds));
+        await Assert.That(firstPageIds.Intersect(secondPageIds)).IsEmpty();
     }
 }

--- a/TelnyxSharp.Tests/NumberManagementTestBase.cs
+++ b/TelnyxSharp.Tests/NumberManagementTestBase.cs
@@ -1,11 +1,14 @@
 using System.Collections.Concurrent;
-using Xunit.Abstractions;
+using System.Text.RegularExpressions;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
 
 namespace TelnyxSharp.Tests
 {
-    public abstract class NumberManagementTestBase : TelnyxTestBase, IAsyncLifetime
+    public abstract class NumberManagementTestBase : TelnyxTestBase
     {
-        protected readonly ITestOutputHelper Output;
+        protected readonly TestOutput Output = new();
         protected readonly ConcurrentBag<string> PhoneNumbersToCleanup = new();
         protected readonly ConcurrentBag<string> ReservationsToCleanup = new();
         protected readonly ConcurrentBag<string> OrdersToCleanup = new();
@@ -16,9 +19,8 @@ namespace TelnyxSharp.Tests
         protected readonly bool AllowCostIncurringTests;
         protected readonly bool AllowVolatileTests;
 
-        protected NumberManagementTestBase(ITestOutputHelper output)
+        protected NumberManagementTestBase()
         {
-            Output = output;
             TestAreaCode = Environment.GetEnvironmentVariable("TELNYX_TEST_AREA_CODE") ?? "212";
             TestCountry = Environment.GetEnvironmentVariable("TELNYX_TEST_COUNTRY") ?? "US";
             MaxTestNumbers = int.TryParse(Environment.GetEnvironmentVariable("TELNYX_TEST_MAX_NUMBERS"), out var max) ? max : 5;
@@ -36,12 +38,8 @@ namespace TelnyxSharp.Tests
             Output.WriteLine($"  COST TESTS ALLOWED: {AllowCostIncurringTests}");
         }
 
-        public virtual Task InitializeAsync()
-        {
-            return Task.CompletedTask;
-        }
-
-        public virtual async Task DisposeAsync()
+        [After(Test)]
+        public virtual async Task NumberManagementCleanupAsync()
         {
             if (!EnableCleanup || !IsIntegrationTest)
             {
@@ -104,7 +102,9 @@ namespace TelnyxSharp.Tests
         {
             if (!AllowCostIncurringTests)
             {
-                return; // Skip test - cost-incurring tests require TELNYX_ALLOW_COST_TESTS=true environment variable
+                // Cost-incurring tests require TELNYX_ALLOW_COST_TESTS=true.
+                throw new global::TUnit.Core.Exceptions.SkipTestException(
+                    "TELNYX_ALLOW_COST_TESTS not set - skipping cost-incurring test");
             }
         }
 
@@ -112,24 +112,29 @@ namespace TelnyxSharp.Tests
         {
             if (!AllowVolatileTests)
             {
-                return; // Skip test - volatile tests require TELNYX_ALLOW_VOLATILE_TESTS=true environment variable
+                // Volatile tests require TELNYX_ALLOW_VOLATILE_TESTS=true.
+                throw new global::TUnit.Core.Exceptions.SkipTestException(
+                    "TELNYX_ALLOW_VOLATILE_TESTS not set - skipping volatile test");
             }
         }
 
-        protected void AssertNotEmpty(string value, string fieldName)
+        protected static async Task AssertNotEmpty(string value, string fieldName)
         {
-            Assert.False(string.IsNullOrWhiteSpace(value), $"{fieldName} should not be empty");
+            await Assert.That(string.IsNullOrWhiteSpace(value)).IsFalse();
         }
 
-        protected void AssertValidPhoneNumber(string phoneNumber)
+        protected static async Task AssertValidPhoneNumber(string phoneNumber)
         {
-            Assert.NotNull(phoneNumber);
-            Assert.Matches(@"^\+?[1-9]\d{1,14}$", phoneNumber);
+            await Assert.That(phoneNumber).IsNotNull();
+            await Assert.That(Regex.IsMatch(phoneNumber, @"^\+?[1-9]\d{1,14}$")).IsTrue();
         }
+    }
 
-        public override void Dispose()
-        {
-            base.Dispose();
-        }
+    /// <summary>
+    /// Lightweight replacement for xUnit's ITestOutputHelper that writes to the console.
+    /// </summary>
+    public sealed class TestOutput
+    {
+        public void WriteLine(string message) => Console.WriteLine(message);
     }
 }

--- a/TelnyxSharp.Tests/Numbers/NumberManagementTestFixture.cs
+++ b/TelnyxSharp.Tests/Numbers/NumberManagementTestFixture.cs
@@ -7,12 +7,10 @@ using TelnyxSharp;
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.PhoneNumberConfigurations;
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.PhoneNumberOrders;
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.PhoneNumberSearch;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace TelnyxSharp.Tests.Numbers
 {
-    public class NumberManagementTestFixture : IAsyncLifetime
+    public class NumberManagementTestFixture
     {
         private readonly TelnyxClient _client;
         private readonly bool _runIntegrationTests;

--- a/TelnyxSharp.Tests/Numbers/OrchestratedNumberManagementTests.cs
+++ b/TelnyxSharp.Tests/Numbers/OrchestratedNumberManagementTests.cs
@@ -4,8 +4,9 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.PhoneNumberOrders;
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.PhoneNumberReservations;
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.PhoneNumberSearch;
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.PhoneNumberOrders;
-using Xunit;
-using Xunit.Abstractions;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
 
 namespace TelnyxSharp.Tests.Numbers
 {
@@ -16,23 +17,20 @@ namespace TelnyxSharp.Tests.Numbers
     /// Phase 2: Purchase one number and test configurations
     /// Phase 3: Optional reservation tests
     /// Phase 4: Cleanup
-    /// 
+    ///
     /// NOTE: Tests are named with Phase_XX prefix to control execution order
     /// </summary>
-    [Collection("NumberManagement")]
-    [Trait("Category", "Integration")]
-    [Trait("Module", "Numbers")]
-    public class OrchestratedNumberManagementTests : IClassFixture<NumberManagementTestFixture>, IAsyncLifetime
+    public sealed class OrchestratedNumberManagementTests
     {
-        private readonly ITestOutputHelper _output;
+        private readonly TestOutput _output = new();
         private readonly TelnyxClient _client;
         private readonly bool _runIntegrationTests;
         private readonly bool _purchaseTestNumber;
         private readonly bool _testReservations;
         private readonly string _testAreaCode;
         private readonly string _testCountry;
-        private readonly NumberManagementTestFixture _fixture;
-        
+        private readonly NumberManagementTestFixture _fixture = new();
+
         // Shared state across test phases (now from fixture)
         private string? _availableNumberToPurchase => _fixture.AvailableNumberToPurchase;
         private string? _purchasedNumberId => _fixture.PurchasedNumberId;
@@ -41,11 +39,8 @@ namespace TelnyxSharp.Tests.Numbers
         private string? _reservationId;
         private readonly ConcurrentBag<string> _commentsToCleanup = new();
 
-        public OrchestratedNumberManagementTests(ITestOutputHelper output, NumberManagementTestFixture fixture)
+        public OrchestratedNumberManagementTests()
         {
-            _output = output;
-            _fixture = fixture;
-            
             // Load configuration
             _runIntegrationTests = Environment.GetEnvironmentVariable("TELNYX_RUN_INTEGRATION_TESTS")?.ToLower() == "true";
             _purchaseTestNumber = Environment.GetEnvironmentVariable("TELNYX_PURCHASE_TEST_NUMBER")?.ToLower() == "true";
@@ -68,7 +63,7 @@ namespace TelnyxSharp.Tests.Numbers
 
         #region Phase 1: Read-Only Tests (No Purchase Required)
 
-        [Fact]
+        [Test]
         public async Task Phase1_01_SearchAvailableNumbers_ByAreaCode()
         {
             if (!_runIntegrationTests) return;
@@ -85,8 +80,8 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await _client.PhoneNumbers.PhoneNumberSearch.AvailableNumbers(request);
             
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
             _output.WriteLine($"Found {response.Data.Count} available numbers");
             
             // Numbers are handled by the fixture now
@@ -101,7 +96,7 @@ namespace TelnyxSharp.Tests.Numbers
             }
         }
 
-        [Fact]
+        [Test]
         public async Task Phase1_02_SearchAvailableNumbers_WithFeatures()
         {
             if (!_runIntegrationTests) return;
@@ -117,8 +112,8 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await _client.PhoneNumbers.PhoneNumberSearch.AvailableNumbers(request);
             
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
             
             foreach (var number in response.Data)
             {
@@ -126,7 +121,7 @@ namespace TelnyxSharp.Tests.Numbers
             }
         }
 
-        [Fact]
+        [Test]
         public async Task Phase1_03_SearchAvailableNumberBlocks()
         {
             if (!_runIntegrationTests) return;
@@ -140,12 +135,12 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await _client.PhoneNumbers.PhoneNumberSearch.ListAvailableNumberBlocks(request);
             
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
             _output.WriteLine($"Number blocks response received");
         }
 
-        [Fact]
+        [Test]
         public async Task Phase1_04_ListExistingOrders()
         {
             if (!_runIntegrationTests) return;
@@ -159,12 +154,12 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await _client.PhoneNumbers.PhoneNumberOrders.List(request);
             
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
             _output.WriteLine($"Found existing orders in account");
         }
 
-        [Fact]
+        [Test]
         public async Task Phase1_05_ListExistingReservations()
         {
             if (!_runIntegrationTests) return;
@@ -178,12 +173,12 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await _client.PhoneNumbers.PhoneNumberReservations.List(request);
             
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
             _output.WriteLine($"Found existing reservations in account");
         }
 
-        [Fact]
+        [Test]
         public async Task Phase1_06_ListOwnedPhoneNumbers()
         {
             if (!_runIntegrationTests) return;
@@ -197,8 +192,8 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await _client.PhoneNumbers.PhoneNumberConfiguration.List(request);
             
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
             
             _output.WriteLine($"Account currently owns {response.Data?.Count ?? 0} phone numbers");
             
@@ -215,7 +210,7 @@ namespace TelnyxSharp.Tests.Numbers
 
         #region Phase 2: Purchase & Configure (Requires TELNYX_PURCHASE_TEST_NUMBER=true)
 
-        [Fact]
+        [Test]
         public async Task Phase2_01_CheckTestNumber()
         {
             if (!_runIntegrationTests || !_purchaseTestNumber) 
@@ -230,17 +225,17 @@ namespace TelnyxSharp.Tests.Numbers
             if (!string.IsNullOrEmpty(_purchasedNumber))
             {
                 _output.WriteLine($"Using test number: {_purchasedNumber} (ID: {_purchasedNumberId})");
-                Assert.NotNull(_purchasedNumber);
-                Assert.NotNull(_purchasedNumberId);
+                await Assert.That(_purchasedNumber).IsNotNull();
+                await Assert.That(_purchasedNumberId).IsNotNull();
             }
             else
             {
                 _output.WriteLine("ERROR: No test number available - fixture failed to initialize");
-                Assert.NotNull(_purchasedNumber);
+                await Assert.That(_purchasedNumber).IsNotNull();
             }
         }
 
-        [Fact]
+        [Test]
         public async Task Phase2_02_GetPurchasedNumberDetails()
         {
             if (!_runIntegrationTests || !_purchaseTestNumber || string.IsNullOrEmpty(_purchasedNumber)) return;
@@ -269,8 +264,8 @@ namespace TelnyxSharp.Tests.Numbers
                 if (!string.IsNullOrEmpty(_purchasedNumberId))
                 {
                     var details = await _client.PhoneNumbers.PhoneNumberConfiguration.Get(_purchasedNumberId);
-                    Assert.NotNull(details);
-                    Assert.NotNull(details.Data);
+                    await Assert.That(details).IsNotNull();
+                    await Assert.That(details.Data).IsNotNull();
                 }
             }
             else
@@ -279,7 +274,7 @@ namespace TelnyxSharp.Tests.Numbers
             }
         }
 
-        [Fact]
+        [Test]
         public async Task Phase2_03_UpdatePhoneNumberConfiguration()
         {
             if (!_runIntegrationTests || !_purchaseTestNumber) 
@@ -315,8 +310,8 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await _client.PhoneNumbers.PhoneNumberConfiguration.Update(_purchasedNumberId!, updateRequest);
             
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
             
             _output.WriteLine($"Updated configuration with tags");
             if (response.Data.Tags != null)
@@ -328,7 +323,7 @@ namespace TelnyxSharp.Tests.Numbers
             }
         }
 
-        [Fact]
+        [Test]
         public async Task Phase2_04_CreateCommentOnOrder()
         {
             if (!_runIntegrationTests || !_purchaseTestNumber || string.IsNullOrEmpty(_orderId)) return;
@@ -344,8 +339,8 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await _client.PhoneNumbers.PhoneNumberOrders.CreateComment(createCommentRequest);
             
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
             
             _output.WriteLine($"Created comment on order {_orderId}");
         }
@@ -354,7 +349,7 @@ namespace TelnyxSharp.Tests.Numbers
 
         #region Phase 3: Reservation Tests (Optional)
 
-        [Fact]
+        [Test]
         public async Task Phase3_01_CreateReservation()
         {
             if (!_runIntegrationTests || !_testReservations) 
@@ -396,8 +391,8 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await _client.PhoneNumbers.PhoneNumberReservations.Create(reservationRequest);
             
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
             
             if (response.Data != null && !string.IsNullOrEmpty(response.Data.Id))
             {
@@ -412,12 +407,14 @@ namespace TelnyxSharp.Tests.Numbers
 
         #region Lifecycle Management
 
-        public Task InitializeAsync()
+        [Before(Test)]
+        public async Task InitializeAsync()
         {
             _output.WriteLine("\n=== Test Suite Initialization ===");
-            return Task.CompletedTask;
+            await _fixture.InitializeAsync();
         }
 
+        [After(Test)]
         public async Task DisposeAsync()
         {
             // No automatic cleanup - numbers tracked in PURCHASE_TRACKING.md for manual cleanup

--- a/TelnyxSharp.Tests/Numbers/PhoneNumberConfigurationTests.cs
+++ b/TelnyxSharp.Tests/Numbers/PhoneNumberConfigurationTests.cs
@@ -1,18 +1,13 @@
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.PhoneNumberConfigurations;
-using Xunit;
-using Xunit.Abstractions;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
 
 namespace TelnyxSharp.Tests.Numbers
 {
-    [Trait("Category", "Integration")]
-    [Trait("Module", "Numbers")]
-    public class PhoneNumberConfigurationTests : NumberManagementTestBase
+    public sealed class PhoneNumberConfigurationTests : NumberManagementTestBase
     {
-        public PhoneNumberConfigurationTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Fact]
+        [Test]
         public async Task ListPhoneNumbers_ReturnsOwnedNumbers()
         {
             SkipIfNotIntegrationTest();
@@ -24,8 +19,8 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await Client.PhoneNumbers.PhoneNumberConfiguration.List(request);
 
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
 
             Output.WriteLine($"Found {response.Data?.Count ?? 0} owned phone numbers");
 
@@ -37,19 +32,19 @@ namespace TelnyxSharp.Tests.Numbers
                     Output.WriteLine($"  Status: {number.Status}");
                     Output.WriteLine($"  Connection: {number.ConnectionName}");
                     Output.WriteLine($"  Messaging Profile: {number.MessagingProfileName}");
-                    
+
                     // ID is a string UUID
-                    Assert.NotNull(number.Id);
-                    Assert.NotEmpty(number.Id);
+                    await Assert.That(number.Id).IsNotNull();
+                    await Assert.That(number.Id).IsNotEmpty();
                     if (!string.IsNullOrEmpty(number.PhoneNumber))
                     {
-                        AssertValidPhoneNumber(number.PhoneNumber);
+                        await AssertValidPhoneNumber(number.PhoneNumber);
                     }
                 }
             }
         }
 
-        [Fact]
+        [Test]
         public async Task GetPhoneNumber_WithValidId_ReturnsDetails()
         {
             SkipIfNotIntegrationTest();
@@ -73,9 +68,9 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await Client.PhoneNumbers.PhoneNumberConfiguration.Get(phoneNumberId);
 
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
-            Assert.Equal(phoneNumberId, response.Data.Id);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
+            await Assert.That(response.Data.Id).IsEqualTo(phoneNumberId);
             
             Output.WriteLine($"Retrieved phone number: {response.Data.PhoneNumber}");
             Output.WriteLine($"  Type: {response.Data.PhoneNumberType}");
@@ -83,7 +78,7 @@ namespace TelnyxSharp.Tests.Numbers
             Output.WriteLine($"  Created: {response.Data.CreatedAt}");
         }
 
-        [Fact]
+        [Test]
         public async Task UpdatePhoneNumberConfiguration_ModifiesSettings()
         {
             SkipIfNotIntegrationTest();
@@ -116,11 +111,11 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await Client.PhoneNumbers.PhoneNumberConfiguration.Update(phoneNumberId, updateRequest);
 
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
             if (response.Data.Tags != null)
             {
-                Assert.Contains($"{TestPrefix}integration_test", response.Data.Tags);
+                await Assert.That(response.Data.Tags).Contains($"{TestPrefix}integration_test");
             }
 
             // Restore original tags
@@ -133,7 +128,7 @@ namespace TelnyxSharp.Tests.Numbers
             Output.WriteLine("Restored original configuration");
         }
 
-        [Fact]
+        [Test]
         public async Task ListPhoneNumbers_WithFilters_ReturnsFilteredResults()
         {
             SkipIfNotIntegrationTest();
@@ -146,18 +141,18 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await Client.PhoneNumbers.PhoneNumberConfiguration.List(request);
 
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
 
             if (response.Data != null)
             {
                 foreach (var number in response.Data)
                 {
                     Output.WriteLine($"Number: {number.PhoneNumber}, Status: {number.Status}");
-                    
+
                     if (!string.IsNullOrEmpty(number.Status))
                     {
-                        Assert.Equal("active", number.Status.ToLower());
+                        await Assert.That(number.Status.ToLower()).IsEqualTo("active");
                     }
                 }
             }

--- a/TelnyxSharp.Tests/Numbers/PhoneNumberOrdersTests.cs
+++ b/TelnyxSharp.Tests/Numbers/PhoneNumberOrdersTests.cs
@@ -1,20 +1,14 @@
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.PhoneNumberOrders;
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.PhoneNumberSearch;
-using Xunit;
-using Xunit.Abstractions;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
 
 namespace TelnyxSharp.Tests.Numbers
 {
-    [Trait("Category", "Integration")]
-    [Trait("Module", "Numbers")]
-    [Trait("Cost", "PotentialCharges")]
-    public class PhoneNumberOrdersTests : NumberManagementTestBase
+    public sealed class PhoneNumberOrdersTests : NumberManagementTestBase
     {
-        public PhoneNumberOrdersTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Fact]
+        [Test]
         public async Task CreateNumberOrder_WithAvailableNumber_CreatesOrder()
         {
             SkipIfNotIntegrationTest();
@@ -54,8 +48,8 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await Client.PhoneNumbers.PhoneNumberOrders.Create(orderRequest);
 
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
             
             Output.WriteLine($"Created order");
             
@@ -66,7 +60,7 @@ namespace TelnyxSharp.Tests.Numbers
             }
         }
 
-        [Fact]
+        [Test]
         public async Task ListNumberOrders_ReturnsOrders()
         {
             SkipIfNotIntegrationTest();
@@ -79,8 +73,8 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await Client.PhoneNumbers.PhoneNumberOrders.List(request);
 
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
 
             Output.WriteLine($"Found number orders");
 
@@ -90,7 +84,7 @@ namespace TelnyxSharp.Tests.Numbers
             }
         }
 
-        [Fact]
+        [Test]
         public async Task GetNumberOrder_WithValidId_ReturnsOrderDetails()
         {
             SkipIfNotIntegrationTest();
@@ -110,7 +104,7 @@ namespace TelnyxSharp.Tests.Numbers
             Output.WriteLine("Order details test would run here if orders exist");
         }
 
-        [Fact]
+        [Test]
         public async Task CreateAndListComments_OnNumberOrder()
         {
             SkipIfNotIntegrationTest();

--- a/TelnyxSharp.Tests/Numbers/PhoneNumberReservationsTests.cs
+++ b/TelnyxSharp.Tests/Numbers/PhoneNumberReservationsTests.cs
@@ -1,20 +1,14 @@
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.PhoneNumberReservations;
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.PhoneNumberSearch;
-using Xunit;
-using Xunit.Abstractions;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
 
 namespace TelnyxSharp.Tests.Numbers
 {
-    [Trait("Category", "Integration")]
-    [Trait("Module", "Numbers")]
-    [Trait("Cost", "PotentialCharges")]
-    public class PhoneNumberReservationsTests : NumberManagementTestBase
+    public sealed class PhoneNumberReservationsTests : NumberManagementTestBase
     {
-        public PhoneNumberReservationsTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Fact]
+        [Test]
         public async Task CreateReservation_WithAvailableNumbers_CreatesReservation()
         {
             SkipIfNotIntegrationTest();
@@ -52,8 +46,8 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await Client.PhoneNumbers.PhoneNumberReservations.Create(reservationRequest);
 
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
             
             if (response.Data != null && !string.IsNullOrEmpty(response.Data.Id))
             {
@@ -64,7 +58,7 @@ namespace TelnyxSharp.Tests.Numbers
             }
         }
 
-        [Fact]
+        [Test]
         public async Task ListReservations_ReturnsReservations()
         {
             SkipIfNotIntegrationTest();
@@ -77,8 +71,8 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await Client.PhoneNumbers.PhoneNumberReservations.List(request);
 
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
 
             Output.WriteLine($"Reservations list retrieved");
 
@@ -86,7 +80,7 @@ namespace TelnyxSharp.Tests.Numbers
             // The actual structure needs to be determined at runtime
         }
 
-        [Fact]
+        [Test]
         public async Task GetReservation_WithValidId_ReturnsReservationDetails()
         {
             SkipIfNotIntegrationTest();
@@ -106,7 +100,7 @@ namespace TelnyxSharp.Tests.Numbers
             Output.WriteLine("Reservation details test would run here if reservations exist");
         }
 
-        [Fact]
+        [Test]
         public async Task ExtendReservation_ExtendsExpirationTime()
         {
             SkipIfNotIntegrationTest();
@@ -149,14 +143,14 @@ namespace TelnyxSharp.Tests.Numbers
 
                 var extendResponse = await Client.PhoneNumbers.PhoneNumberReservations.Extend(reservationId);
 
-                Assert.NotNull(extendResponse);
-                Assert.NotNull(extendResponse.Data);
+                await Assert.That(extendResponse).IsNotNull();
+                await Assert.That(extendResponse.Data).IsNotNull();
                 
                 Output.WriteLine($"Extended reservation successfully");
             }
         }
 
-        [Fact]
+        [Test]
         public async Task ReservationExpiration_TracksExpirationTime()
         {
             SkipIfNotIntegrationTest();
@@ -188,7 +182,7 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await Client.PhoneNumbers.PhoneNumberReservations.Create(request);
 
-            Assert.NotNull(response?.Data);
+            await Assert.That(response?.Data).IsNotNull();
             
             if (response.Data != null && !string.IsNullOrEmpty(response.Data.Id))
             {

--- a/TelnyxSharp.Tests/Numbers/PhoneNumberSearchTests.cs
+++ b/TelnyxSharp.Tests/Numbers/PhoneNumberSearchTests.cs
@@ -1,18 +1,13 @@
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.PhoneNumberSearch;
-using Xunit;
-using Xunit.Abstractions;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
 
 namespace TelnyxSharp.Tests.Numbers
 {
-    [Trait("Category", "Integration")]
-    [Trait("Module", "Numbers")]
-    public class PhoneNumberSearchTests : NumberManagementTestBase
+    public sealed class PhoneNumberSearchTests : NumberManagementTestBase
     {
-        public PhoneNumberSearchTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Fact]
+        [Test]
         public async Task SearchAvailableNumbers_ByAreaCode_ReturnsResults()
         {
             SkipIfNotIntegrationTest();
@@ -29,16 +24,16 @@ namespace TelnyxSharp.Tests.Numbers
             try
             {
                 var responseStrict = await Client.PhoneNumbers.PhoneNumberSearch.AvailableNumbers(requestStrict);
-                Assert.NotNull(responseStrict);
-                Assert.NotNull(responseStrict.Data);
+                await Assert.That(responseStrict).IsNotNull();
+                await Assert.That(responseStrict.Data).IsNotNull();
                 Output.WriteLine($"[Strict mode] Found {responseStrict.Data.Count} available numbers");
-                
+
                 if (responseStrict.Data.Count > 0)
                 {
                     var firstNumber = responseStrict.Data.First();
-                    Assert.NotNull(firstNumber.PhoneNumber);
-                    AssertValidPhoneNumber(firstNumber.PhoneNumber);
-                    Assert.NotNull(firstNumber.RecordType);
+                    await Assert.That(firstNumber.PhoneNumber).IsNotNull();
+                    await AssertValidPhoneNumber(firstNumber.PhoneNumber);
+                    await Assert.That(firstNumber.RecordType).IsNotNull();
                     Output.WriteLine($"First available number: {firstNumber.PhoneNumber}");
                     Output.WriteLine($"Cost: {firstNumber.CostInformation?.MonthlyCost} {firstNumber.CostInformation?.Currency}");
                 }
@@ -57,13 +52,13 @@ namespace TelnyxSharp.Tests.Numbers
                 };
                 
                 var responseBestEffort = await Client.PhoneNumbers.PhoneNumberSearch.AvailableNumbers(requestBestEffort);
-                Assert.NotNull(responseBestEffort);
-                Assert.NotNull(responseBestEffort.Data);
+                await Assert.That(responseBestEffort).IsNotNull();
+                await Assert.That(responseBestEffort.Data).IsNotNull();
                 Output.WriteLine($"[Best effort mode] Found {responseBestEffort.Data.Count} available numbers");
             }
         }
 
-        [Fact]
+        [Test]
         public async Task SearchAvailableNumbers_WithFeatures_ReturnsFilteredResults()
         {
             SkipIfNotIntegrationTest();
@@ -77,8 +72,8 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await Client.PhoneNumbers.PhoneNumberSearch.AvailableNumbers(request);
 
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
 
             foreach (var number in response.Data)
             {
@@ -90,7 +85,7 @@ namespace TelnyxSharp.Tests.Numbers
             }
         }
 
-        [Fact]
+        [Test]
         public async Task SearchAvailableNumbers_ByNationalDestinationCode_ReturnsResults()
         {
             SkipIfNotIntegrationTest();
@@ -107,8 +102,8 @@ namespace TelnyxSharp.Tests.Numbers
             {
                 // Try without best_effort first
                 var response = await Client.PhoneNumbers.PhoneNumberSearch.AvailableNumbers(request);
-                Assert.NotNull(response);
-                Assert.NotNull(response.Data);
+                await Assert.That(response).IsNotNull();
+                await Assert.That(response.Data).IsNotNull();
                 Output.WriteLine($"[Strict mode] Found {response.Data.Count} numbers");
                 
                 foreach (var number in response.Data)
@@ -127,8 +122,8 @@ namespace TelnyxSharp.Tests.Numbers
                 
                 request.BestEffort = true;
                 var response = await Client.PhoneNumbers.PhoneNumberSearch.AvailableNumbers(request);
-                Assert.NotNull(response);
-                Assert.NotNull(response.Data);
+                await Assert.That(response).IsNotNull();
+                await Assert.That(response.Data).IsNotNull();
                 Output.WriteLine($"[Best effort mode] Found {response.Data.Count} numbers");
                 
                 foreach (var number in response.Data)
@@ -142,7 +137,7 @@ namespace TelnyxSharp.Tests.Numbers
             }
         }
 
-        [Fact]
+        [Test]
         public async Task SearchAvailableNumbers_WithPagination_ReturnsPagedResults()
         {
             SkipIfNotIntegrationTest();
@@ -155,13 +150,13 @@ namespace TelnyxSharp.Tests.Numbers
 
             var firstPage = await Client.PhoneNumbers.PhoneNumberSearch.AvailableNumbers(request);
 
-            Assert.NotNull(firstPage);
-            Assert.NotNull(firstPage.Data);
+            await Assert.That(firstPage).IsNotNull();
+            await Assert.That(firstPage.Data).IsNotNull();
             
             Output.WriteLine($"Found {firstPage.Data.Count} numbers in first request");
         }
 
-        [Fact]
+        [Test]
         public async Task SearchAvailableNumberBlocks_ReturnsResults()
         {
             SkipIfNotIntegrationTest();
@@ -174,13 +169,13 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await Client.PhoneNumbers.PhoneNumberSearch.ListAvailableNumberBlocks(request);
 
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
 
             Output.WriteLine($"Number blocks response received");
         }
 
-        [Fact]
+        [Test]
         public async Task SearchAvailableNumbers_InvalidCountryCode_ReturnsEmptyOrError()
         {
             SkipIfNotIntegrationTest();
@@ -196,10 +191,10 @@ namespace TelnyxSharp.Tests.Numbers
                 var response = await Client.PhoneNumbers.PhoneNumberSearch.AvailableNumbers(request);
                 
                 // Some APIs might return empty results instead of error
-                Assert.NotNull(response);
+                await Assert.That(response).IsNotNull();
                 if (response.Data != null)
                 {
-                    Assert.Empty(response.Data);
+                    await Assert.That(response.Data).IsEmpty();
                 }
             }
             catch (Exception ex)
@@ -209,7 +204,7 @@ namespace TelnyxSharp.Tests.Numbers
             }
         }
 
-        [Fact]
+        [Test]
         public async Task SearchAvailableNumbers_SpecificNumberType_ReturnsCorrectType()
         {
             SkipIfNotIntegrationTest();
@@ -223,16 +218,16 @@ namespace TelnyxSharp.Tests.Numbers
 
             var response = await Client.PhoneNumbers.PhoneNumberSearch.AvailableNumbers(request);
 
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            await Assert.That(response).IsNotNull();
+            await Assert.That(response.Data).IsNotNull();
 
             foreach (var number in response.Data)
             {
                 Output.WriteLine($"Number: {number.PhoneNumber}, Type: {number.PhoneNumberType}");
-                
+
                 if (!string.IsNullOrEmpty(number.PhoneNumberType))
                 {
-                    Assert.Equal("local", number.PhoneNumberType.ToLower());
+                    await Assert.That(number.PhoneNumberType.ToLower()).IsEqualTo("local");
                 }
             }
         }

--- a/TelnyxSharp.Tests/Properties/AssemblyInfo.cs
+++ b/TelnyxSharp.Tests/Properties/AssemblyInfo.cs
@@ -1,6 +1,15 @@
-using Xunit;
+using TUnit.Core;
+using TUnit.Core.Interfaces;
+using TelnyxSharp.Tests;
 
-// Configure xUnit test execution behavior
-// Disable test parallelization to ensure integration tests run sequentially
-// This prevents race conditions and resource conflicts between test phases
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
+// Run integration tests sequentially to avoid race conditions and resource
+// conflicts against the live Telnyx API when TELNYX_API_KEY is set.
+[assembly: ParallelLimiter<SingleThreadedParallelLimit>]
+
+namespace TelnyxSharp.Tests
+{
+    public sealed class SingleThreadedParallelLimit : TUnit.Core.Interfaces.IParallelLimit
+    {
+        public int Limit => 1;
+    }
+}

--- a/TelnyxSharp.Tests/RestRequestQueryBuilderTests.cs
+++ b/TelnyxSharp.Tests/RestRequestQueryBuilderTests.cs
@@ -1,12 +1,15 @@
-﻿using RestSharp;
 using System.Text.Json.Serialization;
+using TelnyxSharp.Base;
 using TelnyxSharp.Enums;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
 
 namespace TelnyxSharp.Tests
 {
-    public class RestRequestQueryBuilderTests
+    public sealed class RestRequestQueryBuilderTests
     {
-        private readonly RestRequest _sut = new();
+        private readonly TelnyxRequest _sut = new("");
 
         [JsonConverter(typeof(JsonStringEnumConverter))]
         private enum TestStatus
@@ -26,7 +29,7 @@ namespace TelnyxSharp.Tests
             Third
         }
 
-        private string GetQueryString(RestRequest request)
+        private static string GetQueryString(TelnyxRequest request)
         {
             var parameters = request.Parameters
                 .Where(p => p.Type == ParameterType.QueryString)
@@ -36,97 +39,97 @@ namespace TelnyxSharp.Tests
             return string.Join("&", parameters);
         }
 
-        [Fact]
-        public void AddFilter_WithEnum_GeneratesCorrectQueryString()
+        [Test]
+        public async Task AddFilter_WithEnum_GeneratesCorrectQueryString()
         {
             var request = _sut.AddFilter("status", TestStatus.Active);
-            Assert.Equal("status=active_status", GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo("status=active_status");
         }
 
-        [Fact]
-        public void AddFilter_WithPlainEnum_GeneratesCorrectQueryString()
+        [Test]
+        public async Task AddFilter_WithPlainEnum_GeneratesCorrectQueryString()
         {
             var request = _sut.AddFilter("level", PlainEnum.First);
-            Assert.Equal("level=First", GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo("level=First");
         }
 
-        [Fact]
-        public void AddFilter_WithNullEnum_GeneratesEmptyQueryString()
+        [Test]
+        public async Task AddFilter_WithNullEnum_GeneratesEmptyQueryString()
         {
             var request = _sut.AddFilter("status", null as TestStatus?);
-            Assert.Equal("", GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo("");
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData(" ")]
-        [InlineData("   ")]
-        [InlineData("\t")]
-        [InlineData("\n")]
-        [InlineData("\r\n")]
-        public void AddFilter_WithNullOrWhitespace_GeneratesEmptyQueryString(string? value)
+        [Test]
+        [Arguments(null)]
+        [Arguments("")]
+        [Arguments(" ")]
+        [Arguments("   ")]
+        [Arguments("\t")]
+        [Arguments("\n")]
+        [Arguments("\r\n")]
+        public async Task AddFilter_WithNullOrWhitespace_GeneratesEmptyQueryString(string? value)
         {
             var request = _sut.AddFilter("key", value);
-            Assert.Equal("", GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo("");
         }
 
-        [Theory]
-        [InlineData("simple", "value", "simple=value")]
-        [InlineData("key with space", "value with space", "key with space=value with space")]
-        [InlineData("key", "!@#$%", "key=!@#$%")]
-        [InlineData("key", "value&more", "key=value&more")]
-        [InlineData("key", " value ", "key= value ")] // Preserves meaningful whitespace
-        public void AddFilter_WithValidString_GeneratesCorrectQueryString(string key, string value, string expected)
+        [Test]
+        [Arguments("simple", "value", "simple=value")]
+        [Arguments("key with space", "value with space", "key with space=value with space")]
+        [Arguments("key", "!@#$%", "key=!@#$%")]
+        [Arguments("key", "value&more", "key=value&more")]
+        [Arguments("key", " value ", "key= value ")] // Preserves meaningful whitespace
+        public async Task AddFilter_WithValidString_GeneratesCorrectQueryString(string key, string value, string expected)
         {
             var request = _sut.AddFilter(key, value);
-            Assert.Equal(expected, GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo(expected);
         }
 
-        [Fact]
-        public void AddFilterList_WithNullList_GeneratesEmptyQueryString()
+        [Test]
+        public async Task AddFilterList_WithNullList_GeneratesEmptyQueryString()
         {
             var request = _sut.AddFilterList("tags", null);
-            Assert.Equal("", GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo("");
         }
 
-        [Fact]
-        public void AddFilterList_WithEmptyList_GeneratesEmptyQueryString()
+        [Test]
+        public async Task AddFilterList_WithEmptyList_GeneratesEmptyQueryString()
         {
             var request = _sut.AddFilterList("tags", new List<string>());
-            Assert.Equal("", GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo("");
         }
 
-        [Fact]
-        public void AddFilterList_WithValues_GeneratesArrayStyleQueryString()
+        [Test]
+        public async Task AddFilterList_WithValues_GeneratesArrayStyleQueryString()
         {
             var values = new List<string> { "one", "two", "three" };
             var request = _sut.AddFilterList("items", values);
-            Assert.Equal("items[]=one&items[]=two&items[]=three", GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo("items[]=one&items[]=two&items[]=three");
         }
 
-        [Fact]
-        public void AddFilterList_WithMixedValues_FiltersOutInvalidValues()
+        [Test]
+        public async Task AddFilterList_WithMixedValues_FiltersOutInvalidValues()
         {
-            var values = new List<string> { "valid", "", null, "also-valid", " ", "\t", "  valid-too  " };
+            var values = new List<string> { "valid", "", null!, "also-valid", " ", "\t", "  valid-too  " };
             var request = _sut.AddFilterList("tags", values);
-            Assert.Equal("tags[]=valid&tags[]=also-valid&tags[]=  valid-too  ", GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo("tags[]=valid&tags[]=also-valid&tags[]=  valid-too  ");
         }
 
-        [Theory]
-        [InlineData(10, "page[number]=1&page[size]=10")]
-        [InlineData(0, "page[number]=1&page[size]=1")]    // Below minimum
-        [InlineData(-1, "page[number]=1&page[size]=1")]   // Below minimum
-        [InlineData(300, "page[number]=1&page[size]=250")] // Above maximum
-        [InlineData(null, "page[number]=1&page[size]=50")] // Default value
-        public void AddPagination_GeneratesCorrectQueryString(int? pageSize, string expected)
+        [Test]
+        [Arguments(10, "page[number]=1&page[size]=10")]
+        [Arguments(0, "page[number]=1&page[size]=1")]    // Below minimum
+        [Arguments(-1, "page[number]=1&page[size]=1")]   // Below minimum
+        [Arguments(300, "page[number]=1&page[size]=250")] // Above maximum
+        [Arguments(null, "page[number]=1&page[size]=50")] // Default value
+        public async Task AddPagination_GeneratesCorrectQueryString(int? pageSize, string expected)
         {
             var request = _sut.AddPagination(pageSize);
-            Assert.Equal(expected, GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo(expected);
         }
 
-        [Fact]
-        public void QueryBuilder_CombiningMultipleFilters_GeneratesCorrectQueryString()
+        [Test]
+        public async Task QueryBuilder_CombiningMultipleFilters_GeneratesCorrectQueryString()
         {
             var request = _sut
                 .AddFilter("status", TestStatus.Active)
@@ -135,51 +138,51 @@ namespace TelnyxSharp.Tests
                 .AddPagination(50);
 
             var queryString = GetQueryString(request);
-            Assert.Equal("page[number]=1&page[size]=50&status=active_status&tags[]=new&tags[]=vip&type=customer", queryString);
+            await Assert.That(queryString).IsEqualTo("page[number]=1&page[size]=50&status=active_status&tags[]=new&tags[]=vip&type=customer");
         }
 
-        [Fact]
-        public void QueryBuilder_WithSpecialCharacters_GeneratesCorrectQueryString()
+        [Test]
+        public async Task QueryBuilder_WithSpecialCharacters_GeneratesCorrectQueryString()
         {
             var request = _sut.AddFilter("complex", "Hello & World!")
                             .AddFilterList("tags", new List<string> { "tag&value", "special!char" });
 
-            Assert.Equal("complex=Hello & World!&tags[]=tag&value&tags[]=special!char", GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo("complex=Hello & World!&tags[]=tag&value&tags[]=special!char");
         }
 
 
-        [Fact]
-        public void AddFilter_WithOperator_GeneratesCorrectQueryString()
+        [Test]
+        public async Task AddFilter_WithOperator_GeneratesCorrectQueryString()
         {
             var request = _sut.AddFilter("filter[created_at]", "2023-01-01", FilterOperator.StartsWith);
-            Assert.Equal("filter[created_at][starts_with]=2023-01-01", GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo("filter[created_at][starts_with]=2023-01-01");
         }
 
-        [Fact]
-        public void AddFilter_WithEnumAndOperator_GeneratesCorrectQueryString()
+        [Test]
+        public async Task AddFilter_WithEnumAndOperator_GeneratesCorrectQueryString()
         {
             var request = _sut.AddFilter("filter[status]", TestStatus.Active, FilterOperator.Equals);
-            Assert.Equal("filter[status][eq]=active_status", GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo("filter[status][eq]=active_status");
         }
 
-        [Fact]
-        public void AddFilter_WithPreformattedKeyAndOperator_AppendsOperatorCorrectly()
+        [Test]
+        public async Task AddFilter_WithPreformattedKeyAndOperator_AppendsOperatorCorrectly()
         {
             var request = _sut.AddFilter("custom_key", "value", FilterOperator.Contains);
-            Assert.Equal("custom_key[contains]=value", GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo("custom_key[contains]=value");
         }
 
-        [Fact]
-        public void AddFilter_WithMultipleOperators_GeneratesDistinctParameters()
+        [Test]
+        public async Task AddFilter_WithMultipleOperators_GeneratesDistinctParameters()
         {
             var request = _sut
                 .AddFilter("filter[created_at]", "2023-01-01", FilterOperator.GreaterThanOrEqualTo)
                 .AddFilter("filter[created_at]", "2023-12-31", FilterOperator.LessThanOrEqualTo);
-            Assert.Equal("filter[created_at][gte]=2023-01-01&filter[created_at][lte]=2023-12-31", GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo("filter[created_at][gte]=2023-01-01&filter[created_at][lte]=2023-12-31");
         }
 
-        [Fact]
-        public void AddFilter_WithComplexFilterChain_GeneratesCorrectQueryString()
+        [Test]
+        public async Task AddFilter_WithComplexFilterChain_GeneratesCorrectQueryString()
         {
             var request = _sut
                 .AddFilter("filter[record_type]", DetailRecordType.Conference)
@@ -189,17 +192,17 @@ namespace TelnyxSharp.Tests
                 .AddFilter("filter[status]", TestStatus.Active)
                 .AddFilter("sort", "created_at");
 
-            Assert.Equal("filter[created_at][gte]=2023-01-01&filter[created_at][lte]=2023-12-31&filter[direction]=inbound&filter[record_type]=conference&filter[status]=active_status&sort=created_at", GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo("filter[created_at][gte]=2023-01-01&filter[created_at][lte]=2023-12-31&filter[direction]=inbound&filter[record_type]=conference&filter[status]=active_status&sort=created_at");
         }
 
-        [Fact]
-        public void AddFilter_MultipleConditionsForSameField_GeneratesCorrectQueryString()
+        [Test]
+        public async Task AddFilter_MultipleConditionsForSameField_GeneratesCorrectQueryString()
         {
             var request = _sut
                 .AddFilter("filter[started_at]", "2022-02-02", FilterOperator.GreaterThan)
                 .AddFilter("filter[started_at]", "2022-03-01", FilterOperator.LessThan);
 
-            Assert.Equal("filter[started_at][gt]=2022-02-02&filter[started_at][lt]=2022-03-01", GetQueryString(request));
+            await Assert.That(GetQueryString(request)).IsEqualTo("filter[started_at][gt]=2022-02-02&filter[started_at][lt]=2022-03-01");
         }
     }
 }

--- a/TelnyxSharp.Tests/TelnyxSharp.Tests.csproj
+++ b/TelnyxSharp.Tests/TelnyxSharp.Tests.csproj
@@ -1,24 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.4"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
-        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="Polly" Version="8.6.3" />
-        <PackageReference Include="RestSharp" Version="112.1.0" />
-        <PackageReference Include="xunit" Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <Using Include="Xunit"/>
+        <PackageReference Include="TUnit" Version="1.22.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TelnyxSharp.Tests/TelnyxTestBase.cs
+++ b/TelnyxSharp.Tests/TelnyxTestBase.cs
@@ -1,6 +1,4 @@
-﻿using Xunit;
-
-namespace TelnyxSharp.Tests
+﻿namespace TelnyxSharp.Tests
 {
     public abstract class TelnyxTestBase : IDisposable
     {
@@ -41,7 +39,9 @@ namespace TelnyxSharp.Tests
         {
             if (!IsIntegrationTest)
             {
-                return; // Skip test - integration tests require TELNYX_API_KEY environment variable
+                // Integration tests require the TELNYX_API_KEY environment variable.
+                throw new global::TUnit.Core.Exceptions.SkipTestException(
+                    "TELNYX_API_KEY not set - skipping integration test");
             }
         }
 

--- a/TelnyxSharp.Tests/WireProtocolTests.cs
+++ b/TelnyxSharp.Tests/WireProtocolTests.cs
@@ -1,0 +1,283 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Polly;
+using Polly.RateLimit;
+using Polly.Retry;
+using TelnyxSharp.Base;
+using TelnyxSharp.Messaging.Models.MessagingUrlDomain.Responses;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+namespace TelnyxSharp.Tests
+{
+    /// <summary>
+    /// Exercises the hand-written HTTP wire path introduced by the RestSharp -> HttpClient migration:
+    /// <see cref="TelnyxRequest.BuildHttpRequestMessage"/> (query/method/body/multipart/header rules)
+    /// and <see cref="BaseOperations.ExecuteAsync{T}"/> (send, deserialize, paginate, 429 retry).
+    /// These tests assert the WIRE, not the parameter store, and run with no TELNYX_API_KEY.
+    /// </summary>
+    public sealed class WireProtocolTests
+    {
+        // ---------------------------------------------------------------------
+        // Test infrastructure
+        // ---------------------------------------------------------------------
+
+        /// <summary>
+        /// An <see cref="HttpMessageHandler"/> that returns canned responses from a queue and records
+        /// every outgoing request (its URI string, method, and the message reference itself).
+        /// </summary>
+        private sealed class RecordingHandler : HttpMessageHandler
+        {
+            private readonly Queue<Func<HttpResponseMessage>> _responses;
+
+            public List<HttpRequestMessage> SentMessages { get; } = new();
+            public List<string> SentUris { get; } = new();
+            public List<HttpMethod> SentMethods { get; } = new();
+
+            public RecordingHandler(params Func<HttpResponseMessage>[] responses)
+            {
+                _responses = new Queue<Func<HttpResponseMessage>>(responses);
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                // Capture at call time: ExecuteAsync wraps the message in `using`, so it is disposed
+                // once the call returns. Read the URI/method now.
+                SentMessages.Add(request);
+                SentUris.Add(request.RequestUri!.ToString());
+                SentMethods.Add(request.Method);
+
+                var factory = _responses.Count > 0
+                    ? _responses.Dequeue()
+                    : throw new InvalidOperationException("RecordingHandler ran out of canned responses.");
+                return Task.FromResult(factory());
+            }
+        }
+
+        private static HttpResponseMessage Json(HttpStatusCode status, string body)
+            => new(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            };
+
+        /// <summary>A 429 response carrying <c>x-ratelimit-reset: 0</c> so the retry incurs no real delay.</summary>
+        private static HttpResponseMessage TooManyRequests()
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+            {
+                Content = new StringContent(string.Empty)
+            };
+            response.Headers.TryAddWithoutValidation("x-ratelimit-reset", "0");
+            return response;
+        }
+
+        /// <summary>A test operation that exposes the protected <see cref="BaseOperations.ExecuteAsync{T}"/>.</summary>
+        private sealed class TestOperations : BaseOperations
+        {
+            public TestOperations(HttpClient client, AsyncRetryPolicy policy) : base(client, policy) { }
+
+            public Task<T> Run<T>(TelnyxRequest request, CancellationToken ct = default)
+                where T : ITelnyxResponse, new()
+                => ExecuteAsync<T>(request, ct);
+        }
+
+        private static HttpClient ClientWith(RecordingHandler handler)
+            => new(handler) { BaseAddress = new Uri("https://api.telnyx.com/v2/") };
+
+        /// <summary>A pass-through policy for the happy/pagination paths (no exception is thrown on 200s).</summary>
+        private static AsyncRetryPolicy NoRetryPolicy()
+            => Policy.Handle<RateLimitRejectedException>().RetryAsync(0);
+
+        /// <summary>A retry policy that retries 429s once with zero delay (avoids real x-ratelimit-reset waits).</summary>
+        private static AsyncRetryPolicy ZeroDelayRetryPolicy()
+            => Policy.Handle<RateLimitRejectedException>().WaitAndRetryAsync(1, _ => TimeSpan.Zero);
+
+        private static string Page(int pageNumber, int totalPages, params string[] ids)
+        {
+            var data = string.Join(",", ids.Select(id =>
+                $"{{\"record_type\":\"messaging_url_domain\",\"id\":\"{id}\",\"url_domain\":\"{id}.example.com\",\"use_case\":\"marketing\"}}"));
+            return $"{{\"data\":[{data}],\"meta\":{{\"total_pages\":{totalPages},\"total_results\":4,\"page_number\":{pageNumber},\"page_size\":2}}}}";
+        }
+
+        // =====================================================================
+        // A) BuildHttpRequestMessage  (public — call directly, no mock needed)
+        // =====================================================================
+
+        [Test]
+        public async Task BuildHttpRequestMessage_AssemblesEncodedQueryWithBracketedAndPaginationKeys()
+        {
+            var request = new TelnyxRequest("messaging_url_domains")
+                .AddFilter("filter[phone_number]", "+15551234567")
+                .AddPagination(50);
+
+            var message = request.BuildHttpRequestMessage();
+
+            // RequestUri is RELATIVE here; .Query/.AbsoluteUri would throw. Assert on the raw string.
+            var uri = message.RequestUri!.OriginalString;
+
+            // Bracketed key + '+' value are percent-encoded by Uri.EscapeDataString.
+            await Assert.That(uri).Contains("filter%5Bphone_number%5D=%2B15551234567");
+            await Assert.That(uri).Contains("page%5Bsize%5D=50");
+            await Assert.That(uri).Contains("page%5Bnumber%5D=1");
+            await Assert.That(uri).StartsWith("messaging_url_domains?");
+        }
+
+        [Test]
+        [Arguments(TelnyxMethod.Get, "GET")]
+        [Arguments(TelnyxMethod.Post, "POST")]
+        [Arguments(TelnyxMethod.Put, "PUT")]
+        [Arguments(TelnyxMethod.Patch, "PATCH")]
+        [Arguments(TelnyxMethod.Delete, "DELETE")]
+        public async Task BuildHttpRequestMessage_MapsMethod(TelnyxMethod method, string expected)
+        {
+            var message = new TelnyxRequest("x", method).BuildHttpRequestMessage();
+            await Assert.That(message.Method.Method).IsEqualTo(expected);
+        }
+
+        [Test]
+        public async Task BuildHttpRequestMessage_JsonBody_SetsApplicationJsonAndRoundTrips()
+        {
+            const string body = "{\"a\":1}";
+            var request = new TelnyxRequest("x", TelnyxMethod.Post).AddJsonBody(body);
+
+            var message = request.BuildHttpRequestMessage();
+
+            await Assert.That(message.Content).IsNotNull();
+            await Assert.That(message.Content!.Headers.ContentType!.MediaType).IsEqualTo("application/json");
+            var roundTripped = await message.Content.ReadAsStringAsync();
+            await Assert.That(roundTripped).IsEqualTo(body);
+        }
+
+        [Test]
+        public async Task BuildHttpRequestMessage_WithFile_ProducesMultipartWithFilePartAndFormField()
+        {
+            var bytes = Encoding.UTF8.GetBytes("%PDF-1.4 fake");
+            var request = new TelnyxRequest("documents", TelnyxMethod.Post)
+                .AddFile("file", bytes, "doc.pdf")
+                .AddParameter("customer_reference", "abc");
+
+            var message = request.BuildHttpRequestMessage();
+
+            await Assert.That(message.Content).IsTypeOf<MultipartFormDataContent>();
+            await Assert.That(message.Content!.Headers.ContentType!.MediaType).IsEqualTo("multipart/form-data");
+
+            var multipart = (MultipartFormDataContent)message.Content;
+            var parts = multipart.ToList();
+
+            // File part: name="file", filename="doc.pdf", payload round-trips.
+            var filePart = parts.Single(p => p.Headers.ContentDisposition!.Name!.Trim('"') == "file");
+            await Assert.That(filePart.Headers.ContentDisposition!.FileName!.Trim('"')).IsEqualTo("doc.pdf");
+            await Assert.That(await filePart.ReadAsStringAsync()).IsEqualTo("%PDF-1.4 fake");
+
+            // Non-query GetOrPost parameter becomes a form field (it is NOT placed on the query string).
+            var formField = parts.Single(p => p.Headers.ContentDisposition!.Name!.Trim('"') == "customer_reference");
+            await Assert.That(await formField.ReadAsStringAsync()).IsEqualTo("abc");
+
+            // And nothing leaked into the query string when a file is present.
+            await Assert.That(message.RequestUri!.OriginalString).IsEqualTo("documents");
+        }
+
+        [Test]
+        public async Task BuildHttpRequestMessage_ContentTypeHeader_IsOwnedByContentNotAddedAsRequestHeader()
+        {
+            var request = new TelnyxRequest("x", TelnyxMethod.Post)
+                .AddJsonBody("{\"a\":1}")
+                .AddHeader("Content-Type", "multipart/form-data");
+
+            // Must not throw (adding Content-Type to HttpRequestMessage.Headers would).
+            var message = request.BuildHttpRequestMessage();
+
+            // The request-level headers must NOT carry Content-Type. Note: HttpRequestHeaders.Contains
+            // ("Content-Type") itself throws (it is a content header), so enumerate the request headers
+            // instead — that is the very BCL constraint the production skip-rule exists to respect.
+            var requestHeaderNames = message.Headers.Select(h => h.Key).ToList();
+            await Assert.That(requestHeaderNames.Any(n =>
+                string.Equals(n, "Content-Type", StringComparison.OrdinalIgnoreCase))).IsFalse();
+            // ...and the content keeps its own (json), undisturbed by the ignored header.
+            await Assert.That(message.Content!.Headers.ContentType!.MediaType).IsEqualTo("application/json");
+        }
+
+        // =====================================================================
+        // B) ExecuteAsync via a mocked HttpMessageHandler
+        // =====================================================================
+
+        [Test]
+        public async Task ExecuteAsync_SendsCorrectRelativeUriQueryAndMethodToHandler()
+        {
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.OK, Page(1, 1, "a", "b")));
+            using var client = ClientWith(handler);
+            var ops = new TestOperations(client, NoRetryPolicy());
+
+            var request = new TelnyxRequest("messaging_url_domains")
+                .AddFilter("filter[record_type]", "messaging_url_domain")
+                .AddPagination(2);
+
+            var result = await ops.Run<ListMessagingUrlDomainsResponse>(request);
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Get);
+            var uri = handler.SentUris.Single();
+            await Assert.That(uri).StartsWith("https://api.telnyx.com/v2/messaging_url_domains?");
+            await Assert.That(uri).Contains("filter%5Brecord_type%5D=messaging_url_domain");
+            await Assert.That(uri).Contains("page%5Bsize%5D=2");
+            await Assert.That(uri).Contains("page%5Bnumber%5D=1");
+
+            // Sanity: deserialization populated Meta + Data (else pagination tests would pass for the wrong reason).
+            await Assert.That(result.IsSuccessful).IsTrue();
+            await Assert.That(result.Meta).IsNotNull();
+            await Assert.That(result.Data!.Count).IsEqualTo(2);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_Paginates_RebuildsFreshMessagePerPageAndAggregatesData()
+        {
+            // Page 1 says total_pages=2; page 2 is the final page.
+            var handler = new RecordingHandler(
+                () => Json(HttpStatusCode.OK, Page(1, 2, "a", "b")),
+                () => Json(HttpStatusCode.OK, Page(2, 2, "c", "d")));
+            using var client = ClientWith(handler);
+            var ops = new TestOperations(client, NoRetryPolicy());
+
+            var request = new TelnyxRequest("messaging_url_domains").AddPagination(2);
+
+            var result = await ops.Run<ListMessagingUrlDomainsResponse>(request);
+
+            // Exactly two sends.
+            await Assert.That(handler.SentMessages.Count).IsEqualTo(2);
+
+            // Each send used a FRESH HttpRequestMessage (highest-risk behavior: a reused message would throw).
+            await Assert.That(ReferenceEquals(handler.SentMessages[0], handler.SentMessages[1])).IsFalse();
+
+            // First page requests page[number]=1, second page requests page[number]=2.
+            await Assert.That(handler.SentUris[0]).Contains("page%5Bnumber%5D=1");
+            await Assert.That(handler.SentUris[1]).Contains("page%5Bnumber%5D=2");
+
+            // Aggregated Data contains items from BOTH pages, in order.
+            await Assert.That(result.Data!.Count).IsEqualTo(4);
+            await Assert.That(result.Data!.Select(d => d.Id).ToList())
+                .IsEquivalentTo(new[] { "a", "b", "c", "d" });
+        }
+
+        [Test]
+        public async Task ExecuteAsync_429ThenSuccess_RetriesAndSucceeds()
+        {
+            // First send is throttled (429), retry succeeds. ZeroDelayRetryPolicy avoids real waits.
+            var handler = new RecordingHandler(
+                () => TooManyRequests(),
+                () => Json(HttpStatusCode.OK, Page(1, 1, "a", "b")));
+            using var client = ClientWith(handler);
+            var ops = new TestOperations(client, ZeroDelayRetryPolicy());
+
+            var request = new TelnyxRequest("messaging_url_domains").AddPagination(2);
+
+            var result = await ops.Run<ListMessagingUrlDomainsResponse>(request);
+
+            await Assert.That(handler.SentMessages.Count).IsEqualTo(2);
+            await Assert.That(result.IsSuccessful).IsTrue();
+            await Assert.That(result.StatusCode).IsEqualTo(HttpStatusCode.OK);
+            await Assert.That(result.Data!.Count).IsEqualTo(2);
+        }
+    }
+}

--- a/TelnyxSharp/Base/BaseOperations.cs
+++ b/TelnyxSharp/Base/BaseOperations.cs
@@ -1,7 +1,7 @@
-﻿using Polly.RateLimit;
+using Polly.RateLimit;
 using Polly.Retry;
-using RestSharp;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Text.Json;
 using TelnyxSharp.Models;
@@ -14,7 +14,7 @@ namespace TelnyxSharp.Base
     /// </summary>
     public abstract class BaseOperations
     {
-        protected IRestClient Client { get; set; }
+        protected HttpClient Client { get; set; }
         protected AsyncRetryPolicy RateLimitRetryPolicy { get; set; }
 
         /// <summary>
@@ -25,9 +25,9 @@ namespace TelnyxSharp.Base
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseOperations"/> class with the specified client and rate limit retry policy.
         /// </summary>
-        /// <param name="client">The RestSharp client used for making API requests.</param>
+        /// <param name="client">The <see cref="HttpClient"/> used for making API requests.</param>
         /// <param name="rateLimitRetryPolicy">The retry policy for rate-limiting.</param>
-        protected BaseOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+        protected BaseOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
         {
             Client = client;
             RateLimitRetryPolicy = rateLimitRetryPolicy;
@@ -38,10 +38,16 @@ namespace TelnyxSharp.Base
         /// Handles rate-limiting, response deserialization, and pagination.
         /// </summary>
         /// <typeparam name="T">The type of the response model to deserialize into.</typeparam>
-        /// <param name="request">The RestSharp request to execute.</param>
+        /// <param name="request">The request builder to execute.</param>
         /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
         /// <returns>A task representing the asynchronous operation, with a result of type <typeparamref name="T"/>.</returns>
-        protected async Task<T> ExecuteAsync<T>(RestRequest request, CancellationToken cancellationToken = default)
+        [UnconditionalSuppressMessage("Trimming", "IL2070",
+            Justification = "Pagination reflects over Meta/Data on response types preserved by the source-gen context.")]
+        [UnconditionalSuppressMessage("Trimming", "IL2075",
+            Justification = "Pagination reflects over Meta/Data on response types preserved by the source-gen context.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050",
+            Justification = "Pagination builds a List<> for the response's data element type; element types are concrete and preserved.")]
+        protected async Task<T> ExecuteAsync<T>(TelnyxRequest request, CancellationToken cancellationToken = default)
             where T : ITelnyxResponse, new()
         {
             return await RateLimitRetryPolicy.ExecuteAsync(async () =>
@@ -49,39 +55,38 @@ namespace TelnyxSharp.Base
                 // Add a unique correlation ID header for tracking.
                 request.AddOrUpdateHeader("X-Correlation-ID", Guid.NewGuid());
 
-                var response = await Client.ExecuteAsync(request, cancellationToken);
+                using var requestMessage = request.BuildHttpRequestMessage();
+                var response = await Client.SendAsync(requestMessage, cancellationToken);
+                var content = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 // Initialize the result with the response's basic status information.
+                // ErrorMessage is left null on HTTP error status (matching RestSharp): the
+                // deserialized Errors[] carries detail.
                 var result = new T
                 {
                     StatusCode = response.StatusCode,
-                    IsSuccessful = response.IsSuccessful,
-                    ErrorMessage = response.ErrorMessage
+                    IsSuccessful = response.IsSuccessStatusCode,
+                    ErrorMessage = null
                 };
 
                 // Handle rate-limiting by checking for 429 Too Many Requests status.
                 if (response.StatusCode == HttpStatusCode.TooManyRequests)
                 {
-                    var resetSeconds = response.Headers?
-                        .FirstOrDefault(h => h.Name.Equals("x-ratelimit-reset", StringComparison.OrdinalIgnoreCase))?
-                        .Value?.ToString();
-
-                    var delay = int.TryParse(resetSeconds, out var parsedDelay) ? parsedDelay : 1;
-                    throw new RateLimitRejectedException(TimeSpan.FromSeconds(delay));
+                    throw new RateLimitRejectedException(TimeSpan.FromSeconds(GetRateLimitResetSeconds(response)));
                 }
 
                 // If the response is successful and contains content, attempt to deserialize it.
-                if (response is not { IsSuccessful: true, Content: not null }) return result;
+                if (!response.IsSuccessStatusCode || string.IsNullOrEmpty(content)) return result;
 
                 var deserializedResult =
-                    JsonSerializer.Deserialize<T>(response.Content, TelnyxJsonSerializerContext.Default.Options);
+                    JsonSerializer.Deserialize<T>(content, TelnyxJsonSerializerContext.Default.Options);
 
                 if (deserializedResult == null) return result;
 
                 result = deserializedResult;
                 result.StatusCode = response.StatusCode;
-                result.IsSuccessful = response.IsSuccessful;
-                result.ErrorMessage = response.ErrorMessage;
+                result.IsSuccessful = response.IsSuccessStatusCode;
+                result.ErrorMessage = null;
 
                 // Handle pagination if the response includes paginated data.
                 var pageParam = request.Parameters.FirstOrDefault(p => p.Name == "page[number]");
@@ -93,7 +98,7 @@ namespace TelnyxSharp.Base
 
                 var dataType = dataProperty.PropertyType.GetGenericArguments()[0];
                 var listType = typeof(List<>).MakeGenericType(dataType);
-                var allData = (IList)Activator.CreateInstance(listType);
+                var allData = (IList)Activator.CreateInstance(listType)!;
 
                 if (dataProperty.GetValue(result) is IEnumerable initialData)
                     foreach (var item in initialData)
@@ -107,29 +112,26 @@ namespace TelnyxSharp.Base
                         request.AddOrUpdateHeader("X-Correlation-ID", Guid.NewGuid());
                         request.RemoveParameter(pageParam);
                         request.AddParameter("page[number]", meta.PageNumber + 1);
-                        response = await Client.ExecuteAsync(request, cancellationToken);
 
-                        if (response.StatusCode != HttpStatusCode.TooManyRequests) return Task.CompletedTask;
+                        using var pageMessage = request.BuildHttpRequestMessage();
+                        response = await Client.SendAsync(pageMessage, cancellationToken);
+                        content = await response.Content.ReadAsStringAsync(cancellationToken);
 
-                        var resetSeconds = response.Headers?
-                            .FirstOrDefault(h =>
-                                h.Name.Equals("x-ratelimit-reset", StringComparison.OrdinalIgnoreCase))?
-                            .Value?.ToString();
+                        if (response.StatusCode != HttpStatusCode.TooManyRequests) return;
 
-                        var delay = int.TryParse(resetSeconds, out var parsedDelay) ? parsedDelay : 1;
-                        throw new RateLimitRejectedException(TimeSpan.FromSeconds(delay));
+                        throw new RateLimitRejectedException(TimeSpan.FromSeconds(GetRateLimitResetSeconds(response)));
                     });
 
                     // If the response is not successful, break the loop.
-                    if (!response.IsSuccessful || response.Content == null)
+                    if (!response.IsSuccessStatusCode || string.IsNullOrEmpty(content))
                     {
                         result.IsSuccessful = false;
                         result.StatusCode = response.StatusCode;
-                        result.ErrorMessage = response.ErrorMessage;
+                        result.ErrorMessage = null;
                         break;
                     }
 
-                    var nextResult = JsonSerializer.Deserialize<T>(response.Content,
+                    var nextResult = JsonSerializer.Deserialize<T>(content,
                         TelnyxJsonSerializerContext.Default.Options);
                     if (nextResult == null) break;
 
@@ -139,13 +141,25 @@ namespace TelnyxSharp.Base
                             allData.Add(item);
 
                     metaProperty.SetValue(result, metaProperty.GetValue(nextResult));
-                    meta = (PaginationMeta)metaProperty.GetValue(result);
+                    meta = (PaginationMeta)metaProperty.GetValue(result)!;
                     pageParam = request.Parameters.FirstOrDefault(p => p.Name == "page[number]");
                 }
 
                 dataProperty.SetValue(result, allData);
                 return result;
             });
+        }
+
+        /// <summary>
+        /// Reads the <c>x-ratelimit-reset</c> header (in seconds) from a response, defaulting to 1.
+        /// </summary>
+        private static int GetRateLimitResetSeconds(HttpResponseMessage response)
+        {
+            string? resetSeconds = null;
+            if (response.Headers.TryGetValues("x-ratelimit-reset", out var values))
+                resetSeconds = values.FirstOrDefault();
+
+            return int.TryParse(resetSeconds, out var parsedDelay) ? parsedDelay : 1;
         }
     }
 }

--- a/TelnyxSharp/Base/TelnyxRequest.cs
+++ b/TelnyxSharp/Base/TelnyxRequest.cs
@@ -1,0 +1,247 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Text.Json;
+
+namespace TelnyxSharp.Base
+{
+    /// <summary>
+    /// The HTTP method for a <see cref="TelnyxRequest"/>.
+    /// Mirrors the RestSharp <c>Method</c> names the operation files reference.
+    /// </summary>
+    public enum TelnyxMethod
+    {
+        Get,
+        Post,
+        Put,
+        Patch,
+        Delete
+    }
+
+    /// <summary>
+    /// Describes how a parameter participates in a request.
+    /// Mirrors the RestSharp <c>ParameterType</c> names the operation files reference.
+    /// </summary>
+    public enum ParameterType
+    {
+        /// <summary>Parameter is appended to the query string.</summary>
+        QueryString,
+
+        /// <summary>
+        /// Parameter is added to the query string, or (when a file is present) to the multipart body.
+        /// This is the default for <see cref="TelnyxRequest.AddParameter(string, object?)"/>.
+        /// </summary>
+        GetOrPost,
+
+        /// <summary>Parameter represents the raw request body.</summary>
+        RequestBody
+    }
+
+    /// <summary>
+    /// A single parameter entry. Stored in an ordered list so duplicate names
+    /// (e.g. repeated <c>key[]</c> filters) are preserved on the wire.
+    /// </summary>
+    public sealed class TelnyxParameter
+    {
+        public string Name { get; }
+        public object? Value { get; }
+        public ParameterType Type { get; }
+
+        public TelnyxParameter(string name, object? value, ParameterType type)
+        {
+            Name = name;
+            Value = value;
+            Type = type;
+        }
+    }
+
+    /// <summary>
+    /// A request builder that mirrors the RestSharp <c>RestRequest</c> surface the operation files use,
+    /// but produces native <see cref="HttpRequestMessage"/> instances backed by <see cref="HttpClient"/>.
+    /// <para>
+    /// A single builder may be sent more than once (pagination increments <c>page[number]</c> and re-sends),
+    /// so callers must obtain a fresh <see cref="HttpRequestMessage"/> for every send via
+    /// <see cref="BuildHttpRequestMessage"/> — an <see cref="HttpRequestMessage"/> cannot be reused.
+    /// </para>
+    /// </summary>
+    public class TelnyxRequest
+    {
+        private readonly List<TelnyxParameter> _parameters = new();
+        private readonly List<KeyValuePair<string, string>> _headers = new();
+        private readonly List<FilePart> _files = new();
+        private string? _body;
+
+        /// <summary>The relative resource path (e.g. <c>"documents"</c>), resolved against the client's base address.</summary>
+        public string Resource { get; }
+
+        /// <summary>The HTTP method for this request.</summary>
+        public TelnyxMethod Method { get; }
+
+        /// <summary>The ordered parameter store. Exposed so the pagination loop can locate and replace <c>page[number]</c>.</summary>
+        public IReadOnlyList<TelnyxParameter> Parameters => _parameters;
+
+        private sealed class FilePart
+        {
+            public string Name { get; init; } = string.Empty;
+            public byte[] Bytes { get; init; } = Array.Empty<byte>();
+            public string FileName { get; init; } = string.Empty;
+        }
+
+        /// <summary>Initializes a request for the given resource using <see cref="TelnyxMethod.Get"/>.</summary>
+        public TelnyxRequest(string resource) : this(resource, TelnyxMethod.Get) { }
+
+        /// <summary>Initializes a request for the given resource and method.</summary>
+        public TelnyxRequest(string resource, TelnyxMethod method)
+        {
+            Resource = resource;
+            Method = method;
+        }
+
+        /// <summary>
+        /// Adds a parameter using the default <see cref="ParameterType.GetOrPost"/> behavior.
+        /// </summary>
+        public TelnyxRequest AddParameter(string name, object? value)
+            => AddParameter(name, value, ParameterType.GetOrPost);
+
+        /// <summary>
+        /// Adds a parameter with the specified <see cref="ParameterType"/>.
+        /// </summary>
+        public TelnyxRequest AddParameter(string name, object? value, ParameterType type)
+        {
+            _parameters.Add(new TelnyxParameter(name, value, type));
+            return this;
+        }
+
+        /// <summary>
+        /// Removes a previously added parameter instance (used by the pagination loop to drop the
+        /// current <c>page[number]</c> before re-adding it with an incremented value).
+        /// </summary>
+        public TelnyxRequest RemoveParameter(TelnyxParameter? parameter)
+        {
+            if (parameter != null)
+                _parameters.Remove(parameter);
+            return this;
+        }
+
+        /// <summary>Adds a header, replacing any existing header with the same name.</summary>
+        public TelnyxRequest AddOrUpdateHeader(string name, object value)
+        {
+            _headers.RemoveAll(h => string.Equals(h.Key, name, StringComparison.OrdinalIgnoreCase));
+            _headers.Add(new KeyValuePair<string, string>(name, value?.ToString() ?? string.Empty));
+            return this;
+        }
+
+        /// <summary>Adds a header.</summary>
+        public TelnyxRequest AddHeader(string name, string value)
+        {
+            _headers.Add(new KeyValuePair<string, string>(name, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the JSON request body. The operation files pass an already-serialized JSON string;
+        /// such strings are used verbatim. Any other object is serialized via the source-gen context.
+        /// </summary>
+        public TelnyxRequest AddJsonBody(object body) => AddBody(body);
+
+        /// <summary>
+        /// Sets the JSON request body. The operation files pass an already-serialized JSON string;
+        /// such strings are used verbatim. Any other object is serialized via the source-gen context.
+        /// </summary>
+        [UnconditionalSuppressMessage("Trimming", "IL2026",
+            Justification = "All operation files pass a pre-serialized JSON string; the reflective Serialize fallback is never reached at runtime.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050",
+            Justification = "All operation files pass a pre-serialized JSON string; the reflective Serialize fallback is never reached at runtime.")]
+        public TelnyxRequest AddBody(object body)
+        {
+            _body = body as string
+                ?? JsonSerializer.Serialize(body, body.GetType(), TelnyxJsonSerializerContext.Default.Options);
+            return this;
+        }
+
+        /// <summary>Adds a file as a multipart/form-data part.</summary>
+        public TelnyxRequest AddFile(string name, byte[] bytes, string fileName)
+        {
+            _files.Add(new FilePart { Name = name, Bytes = bytes, FileName = fileName });
+            return this;
+        }
+
+        /// <summary>
+        /// Builds a fresh <see cref="HttpRequestMessage"/> from the current builder state.
+        /// Must be called once per send: <see cref="HttpRequestMessage"/> instances cannot be reused.
+        /// </summary>
+        public HttpRequestMessage BuildHttpRequestMessage()
+        {
+            var query = BuildQueryString();
+            var uri = string.IsNullOrEmpty(query) ? Resource : $"{Resource}?{query}";
+
+            var message = new HttpRequestMessage(MapMethod(Method), uri);
+
+            if (_files.Count > 0)
+            {
+                var multipart = new MultipartFormDataContent();
+                foreach (var file in _files)
+                {
+                    var fileContent = new ByteArrayContent(file.Bytes);
+                    multipart.Add(fileContent, file.Name, file.FileName);
+                }
+
+                // GetOrPost / RequestBody parameters become form fields alongside the file(s).
+                foreach (var p in _parameters)
+                {
+                    if (p.Type is ParameterType.QueryString) continue;
+                    multipart.Add(new StringContent(p.Value?.ToString() ?? string.Empty), p.Name);
+                }
+
+                message.Content = multipart;
+            }
+            else if (_body != null)
+            {
+                message.Content = new StringContent(_body, Encoding.UTF8, "application/json");
+            }
+
+            foreach (var header in _headers)
+            {
+                // Content-Type is owned by the content (multipart boundary / json) — never set it as a request header.
+                if (string.Equals(header.Key, "Content-Type", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                message.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            return message;
+        }
+
+        /// <summary>
+        /// Assembles the query string from QueryString parameters (and, when no file is present,
+        /// GetOrPost parameters). Bracketed keys are escaped via <see cref="Uri.EscapeDataString"/>,
+        /// matching the wire format RestSharp produced. Duplicate names are preserved.
+        /// </summary>
+        private string BuildQueryString()
+        {
+            var parts = new List<string>();
+            var hasFile = _files.Count > 0;
+
+            foreach (var p in _parameters)
+            {
+                var goesToQuery = p.Type == ParameterType.QueryString
+                                  || (p.Type == ParameterType.GetOrPost && !hasFile);
+                if (!goesToQuery) continue;
+                if (p.Value is null) continue;
+
+                parts.Add($"{Uri.EscapeDataString(p.Name)}={Uri.EscapeDataString(p.Value.ToString() ?? string.Empty)}");
+            }
+
+            return string.Join("&", parts);
+        }
+
+        private static HttpMethod MapMethod(TelnyxMethod method) => method switch
+        {
+            TelnyxMethod.Get => HttpMethod.Get,
+            TelnyxMethod.Post => HttpMethod.Post,
+            TelnyxMethod.Put => HttpMethod.Put,
+            TelnyxMethod.Patch => HttpMethod.Patch,
+            TelnyxMethod.Delete => HttpMethod.Delete,
+            _ => HttpMethod.Get
+        };
+    }
+}

--- a/TelnyxSharp/DetailRecords/Operations/DetailRecordsOperations.cs
+++ b/TelnyxSharp/DetailRecords/Operations/DetailRecordsOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.DetailRecords.Interfaces;
 using TelnyxSharp.DetailRecords.Models.Requests;
@@ -7,13 +6,13 @@ using TelnyxSharp.DetailRecords.Models.Responses;
 
 namespace TelnyxSharp.DetailRecords.Operations
 {
-    public class DetailRecordsOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class DetailRecordsOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IDetailRecordsOperations
     {
         /// <inheritdoc />
         public async Task<DetailRecordSearchResponse?> Search(DetailRecordSearchRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("detail_records")
+            var req = new TelnyxRequest("detail_records")
                 .AddPagination(request.PageSize)
                 .AddFilter("filter[record_type]", request.RecordType)
                 .AddFilter("filter[date_range]", request.DateRange);

--- a/TelnyxSharp/Identity/Operations/NumberLookup/LookUpNumberOperations.cs
+++ b/TelnyxSharp/Identity/Operations/NumberLookup/LookUpNumberOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Identity.Interfaces;
 
@@ -8,7 +7,7 @@ namespace TelnyxSharp.Identity.Operations.NumberLookup
     /// <summary>
     /// Provides operations related to managing toll-free numbers, including toll-free verification.
     /// </summary>
-    public class LookUpNumberOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class LookUpNumberOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), ILookUpNumberOperations
     {
         private readonly Lazy<INumberLookupOperations> _numberLookupOperations = new(() =>

--- a/TelnyxSharp/Identity/Operations/NumberLookup/NumberLookupOperations.cs
+++ b/TelnyxSharp/Identity/Operations/NumberLookup/NumberLookupOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Enums;
 using TelnyxSharp.Identity.Interfaces;
@@ -8,14 +7,14 @@ using TelnyxSharp.Identity.Models.NumberLookup.Responses;
 
 namespace TelnyxSharp.Identity.Operations.NumberLookup
 {
-    public class NumberLookupOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class NumberLookupOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), INumberLookupOperations
     {
         /// <inheritdoc />
         public async Task<NumberLookupResponse> LookupPhoneData(NumberLookupRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"number_lookup/{request.PhoneNumber}");
+            var req = new TelnyxRequest($"number_lookup/{request.PhoneNumber}");
 
             foreach (var type in request.NumberLookupTypes)
             {

--- a/TelnyxSharp/Messaging/Operations/SmsMms/AdvancedOptInOptOutOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/SmsMms/AdvancedOptInOptOutOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Messaging.Interfaces;
@@ -8,7 +7,7 @@ using TelnyxSharp.Messaging.Models.AdvancedOptInOptOut.Responses;
 
 namespace TelnyxSharp.Messaging.Operations.SmsMms
 {
-    public class AdvancedOptInOptOutOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class AdvancedOptInOptOutOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IAdvancedOptInOptOutOperations
     {
         /// <inheritdoc />
@@ -20,7 +19,7 @@ namespace TelnyxSharp.Messaging.Operations.SmsMms
             var updatedAtGteFormatted = request.UpdatedAtGte?.ToString("yyyy-MM-ddTHH:mm:ss.ffffffzzz");
             var updatedAtLteFormatted = request.UpdatedAtLte?.ToString("yyyy-MM-ddTHH:mm:ss.ffffffzzz");
 
-            var req = new RestRequest($"messaging_profiles/{profileId}/autoresp_configs")
+            var req = new TelnyxRequest($"messaging_profiles/{profileId}/autoresp_configs")
                 .AddFilter("country_code", request.CountryCode)
                 .AddFilter("created_at[gte]", createdAtGteFormatted)
                 .AddFilter("created_at[lte]", createdAtLteFormatted)
@@ -35,7 +34,7 @@ namespace TelnyxSharp.Messaging.Operations.SmsMms
         public async Task<CreateAutoResponseSettingResponse?> Create(string profileId,
             CreateAutoResponseSettingRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"messaging_profiles/{profileId}/autoresp_configs", Method.Post);
+            var req = new TelnyxRequest($"messaging_profiles/{profileId}/autoresp_configs", TelnyxMethod.Post);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
@@ -46,7 +45,7 @@ namespace TelnyxSharp.Messaging.Operations.SmsMms
         public async Task<GetAutoResponseSettingResponse?> Retrieve(string profileId,
             string autorespCfgId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"messaging_profiles/{profileId}/autoresp_configs/{autorespCfgId}");
+            var req = new TelnyxRequest($"messaging_profiles/{profileId}/autoresp_configs/{autorespCfgId}");
 
             return await ExecuteAsync<GetAutoResponseSettingResponse>(req, cancellationToken);
         }
@@ -56,7 +55,7 @@ namespace TelnyxSharp.Messaging.Operations.SmsMms
             string autorespCfgId, UpdateAutoResponseSettingRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"messaging_profiles/{profileId}/autoresp_configs/{autorespCfgId}", Method.Put);
+            var req = new TelnyxRequest($"messaging_profiles/{profileId}/autoresp_configs/{autorespCfgId}", TelnyxMethod.Put);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
@@ -67,8 +66,8 @@ namespace TelnyxSharp.Messaging.Operations.SmsMms
         public async Task<DeleteAutoResponseSettingResponse?> Delete(string profileId,
             string autorespCfgId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"messaging_profiles/{profileId}/autoresp_configs/{autorespCfgId}",
-                Method.Delete);
+            var req = new TelnyxRequest($"messaging_profiles/{profileId}/autoresp_configs/{autorespCfgId}",
+                TelnyxMethod.Delete);
 
             return await ExecuteAsync<DeleteAutoResponseSettingResponse>(req, cancellationToken);
         }

--- a/TelnyxSharp/Messaging/Operations/SmsMms/MessagesOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/SmsMms/MessagesOperations.cs
@@ -1,5 +1,4 @@
 using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Messaging.Interfaces;
@@ -8,13 +7,13 @@ using TelnyxSharp.Messaging.Models.Messages.Responses;
 
 namespace TelnyxSharp.Messaging.Operations.SmsMms;
 
-public class MessagesOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+public class MessagesOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IMessagesOperations
 {
     /// <inheritdoc />
     public async Task<SendMessageResponse> Send(SendMessageRequest request, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest("messages", Method.Post);
+        var req = new TelnyxRequest("messages", TelnyxMethod.Post);
         req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
         return await ExecuteAsync<SendMessageResponse>(req, cancellationToken);
     }
@@ -22,7 +21,7 @@ public class MessagesOperations(IRestClient client, AsyncRetryPolicy rateLimitRe
     /// <inheritdoc />
     public async Task<LongCodeMessageResponse?> SendLongCode(LongCodeMessageRequest request, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest("messages/long_code", Method.Post);
+        var req = new TelnyxRequest("messages/long_code", TelnyxMethod.Post);
         req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
         return await ExecuteAsync<LongCodeMessageResponse>(req, cancellationToken);
     }
@@ -30,7 +29,7 @@ public class MessagesOperations(IRestClient client, AsyncRetryPolicy rateLimitRe
     /// <inheritdoc />
     public async Task<NumberPoolMessageResponse?> SendUsingNumberPool(NumberPoolMessageRequest request, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest("messages/number_pool", Method.Post);
+        var req = new TelnyxRequest("messages/number_pool", TelnyxMethod.Post);
         req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
         return await ExecuteAsync<NumberPoolMessageResponse>(req, cancellationToken);
     }
@@ -38,7 +37,7 @@ public class MessagesOperations(IRestClient client, AsyncRetryPolicy rateLimitRe
     /// <inheritdoc />
     public async Task<ShortCodeMessageResponse?> SendShortCode(ShortCodeMessageRequest request, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest("messages/short_code", Method.Post);
+        var req = new TelnyxRequest("messages/short_code", TelnyxMethod.Post);
         req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
         return await ExecuteAsync<ShortCodeMessageResponse>(req, cancellationToken);
     }
@@ -46,7 +45,7 @@ public class MessagesOperations(IRestClient client, AsyncRetryPolicy rateLimitRe
     /// <inheritdoc />
     public async Task<GroupMmsMessageResponse?> SendGroupMms(GroupMmsMessageRequest request, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest("messages/group_mms", Method.Post);
+        var req = new TelnyxRequest("messages/group_mms", TelnyxMethod.Post);
         req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
         return await ExecuteAsync<GroupMmsMessageResponse>(req, cancellationToken);
     }
@@ -54,7 +53,7 @@ public class MessagesOperations(IRestClient client, AsyncRetryPolicy rateLimitRe
     /// <inheritdoc />
     public async Task<RetrieveMessageResponse?> RetrieveMessage(string id, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest($"messages/{id}");
+        var req = new TelnyxRequest($"messages/{id}");
         return await ExecuteAsync<RetrieveMessageResponse>(req, cancellationToken);
     }
 }

--- a/TelnyxSharp/Messaging/Operations/SmsMms/MessagingHostedNumbersOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/SmsMms/MessagingHostedNumbersOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Messaging.Interfaces;
@@ -8,14 +7,14 @@ using TelnyxSharp.Messaging.Models.MessagingHostedNumber.Responses;
 
 namespace TelnyxSharp.Messaging.Operations.SmsMms
 {
-    public class MessagingHostedNumbersOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class MessagingHostedNumbersOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IMessagingHostedNumbersOperations
     {
         /// <inheritdoc />
         public async Task<DeleteHostedNumberResponse?> Delete(string id,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"messaging_hosted_numbers/{id}", Method.Delete);
+            var req = new TelnyxRequest($"messaging_hosted_numbers/{id}", TelnyxMethod.Delete);
 
             return await ExecuteAsync<DeleteHostedNumberResponse>(req, cancellationToken);
         }
@@ -24,7 +23,7 @@ namespace TelnyxSharp.Messaging.Operations.SmsMms
         public async Task<GetHostedNumberOrderResponse?> List(
             GetHostedNumberOrderRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"messaging_hosted_number_orders").AddPagination(request.PageSize);
+            var req = new TelnyxRequest($"messaging_hosted_number_orders").AddPagination(request.PageSize);
 
             return await ExecuteAsync<GetHostedNumberOrderResponse>(req, cancellationToken);
         }
@@ -33,7 +32,7 @@ namespace TelnyxSharp.Messaging.Operations.SmsMms
         public async Task<CreateHostedNumberOrderResponse?> Create(
             CreateHostedNumberOrderRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("messaging_hosted_number_orders", Method.Post);
+            var req = new TelnyxRequest("messaging_hosted_number_orders", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CreateHostedNumberOrderResponse>(req, cancellationToken);
@@ -43,7 +42,7 @@ namespace TelnyxSharp.Messaging.Operations.SmsMms
         public async Task<RetrieveHostedNumberOrderResponse?> Retrieve(string id,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"messaging_hosted_number_orders/{id}");
+            var req = new TelnyxRequest($"messaging_hosted_number_orders/{id}");
 
             return await ExecuteAsync<RetrieveHostedNumberOrderResponse>(req, cancellationToken);
         }
@@ -52,7 +51,7 @@ namespace TelnyxSharp.Messaging.Operations.SmsMms
         public async Task<UploadFileHostedNumberOrderResponse?> UploadFileRequired(string id,
             UploadFileHostedNumberOrderRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"messaging_hosted_number_orders/{id}/actions/file_upload", Method.Post);
+            var req = new TelnyxRequest($"messaging_hosted_number_orders/{id}/actions/file_upload", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<UploadFileHostedNumberOrderResponse>(req, cancellationToken);

--- a/TelnyxSharp/Messaging/Operations/SmsMms/MessagingProfileOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/SmsMms/MessagingProfileOperations.cs
@@ -1,5 +1,4 @@
 using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Messaging.Interfaces;
@@ -8,13 +7,13 @@ using TelnyxSharp.Messaging.Models.MessagesProfile.Responses;
 
 namespace TelnyxSharp.Messaging.Operations.SmsMms;
 
-public class MessagingProfileOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+public class MessagingProfileOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IMessagingProfileOperations
 {
     /// <inheritdoc />
     public async Task<MessagingProfilesResponse?> List(MessagingProfilesRequest request, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest("messaging_profiles")
+        var req = new TelnyxRequest("messaging_profiles")
             .AddPagination(request.PageSize)
             .AddFilter("filter[name]", request.NameFilter);
 
@@ -24,7 +23,7 @@ public class MessagingProfileOperations(IRestClient client, AsyncRetryPolicy rat
     /// <inheritdoc />
     public async Task<CreateMessagingProfileResponse?> Create(CreateMessagingProfileRequest request, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest("messaging_profiles", Method.Post);
+        var req = new TelnyxRequest("messaging_profiles", TelnyxMethod.Post);
         req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
         return await ExecuteAsync<CreateMessagingProfileResponse>(req, cancellationToken);
@@ -33,14 +32,14 @@ public class MessagingProfileOperations(IRestClient client, AsyncRetryPolicy rat
     /// <inheritdoc />
     public async Task<RetrieveMessagingProfileResponse> Retrieve(string id, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest($"messaging_profiles/{id}");
+        var req = new TelnyxRequest($"messaging_profiles/{id}");
         return await ExecuteAsync<RetrieveMessagingProfileResponse>(req, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<UpdateMessagingProfileResponse?> Update(string id, UpdateMessagingProfileRequest request, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest($"messaging_profiles/{id}", Method.Patch);
+        var req = new TelnyxRequest($"messaging_profiles/{id}", TelnyxMethod.Patch);
         req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
         return await ExecuteAsync<UpdateMessagingProfileResponse>(req, cancellationToken);
@@ -49,14 +48,14 @@ public class MessagingProfileOperations(IRestClient client, AsyncRetryPolicy rat
     /// <inheritdoc />
     public async Task<DeleteMessagingProfileResponse?> Delete(string id, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest($"messaging_profiles/{id}", Method.Delete);
+        var req = new TelnyxRequest($"messaging_profiles/{id}", TelnyxMethod.Delete);
         return await ExecuteAsync<DeleteMessagingProfileResponse>(req, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<MessagingProfilePhoneNumberResponse?> ListPhoneNumbers(string id, MessagingProfilePhoneNumberRequest request, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest($"messaging_profiles/{id}/phone_numbers")
+        var req = new TelnyxRequest($"messaging_profiles/{id}/phone_numbers")
             .AddPagination(request.PageSize);
 
         return await ExecuteAsync<MessagingProfilePhoneNumberResponse>(req, cancellationToken);
@@ -65,7 +64,7 @@ public class MessagingProfileOperations(IRestClient client, AsyncRetryPolicy rat
     /// <inheritdoc />
     public async Task<MessagingProfileShortCodeResponse?> ListShortCodes(string id, MessagingProfileShortCodeRequest request, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest($"messaging_profiles/{id}/short_codes")
+        var req = new TelnyxRequest($"messaging_profiles/{id}/short_codes")
             .AddPagination(request.PageSize);
 
         return await ExecuteAsync<MessagingProfileShortCodeResponse>(req, cancellationToken);
@@ -74,7 +73,7 @@ public class MessagingProfileOperations(IRestClient client, AsyncRetryPolicy rat
     /// <inheritdoc />
     public async Task<RetrieveMessagingProfileMetricsResponse?> RetrieveMetrics(string id, RetrieveMessagingProfileMetricsRequest request, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest($"messaging_profiles/{id}/metrics")
+        var req = new TelnyxRequest($"messaging_profiles/{id}/metrics")
             .AddFilter("time_frame", request.TimeFrame);
 
         return await ExecuteAsync<RetrieveMessagingProfileMetricsResponse>(req, cancellationToken);
@@ -83,7 +82,7 @@ public class MessagingProfileOperations(IRestClient client, AsyncRetryPolicy rat
     /// <inheritdoc />
     public async Task<MessagingProfileMetricsResponse?> ListMetrics(MessagingProfileMetricsRequest request, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest("messaging_profile_metrics")
+        var req = new TelnyxRequest("messaging_profile_metrics")
             .AddPagination(request.PageSize)
             .AddFilter("id", request.MessagingProfileId)
             .AddFilter("time_frame", request.TimeFrame);

--- a/TelnyxSharp/Messaging/Operations/SmsMms/MessagingUrlDomainOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/SmsMms/MessagingUrlDomainOperations.cs
@@ -1,5 +1,4 @@
 using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Messaging.Interfaces;
 using TelnyxSharp.Messaging.Models.MessagingUrlDomain.Requests;
@@ -7,13 +6,13 @@ using TelnyxSharp.Messaging.Models.MessagingUrlDomain.Responses;
 
 namespace TelnyxSharp.Messaging.Operations.SmsMms;
 
-public class MessagingUrlDomainOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+public class MessagingUrlDomainOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IMessagingUrlDomainOperations
 {
     /// <inheritdoc />
     public async Task<ListMessagingUrlDomainsResponse?> List(ListMessagingUrlDomainsRequest request, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest("messaging_url_domains")
+        var req = new TelnyxRequest("messaging_url_domains")
             .AddPagination(request.PageSize);
 
         return await ExecuteAsync<ListMessagingUrlDomainsResponse>(req, cancellationToken);

--- a/TelnyxSharp/Messaging/Operations/SmsMms/NumberConfigurationOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/SmsMms/NumberConfigurationOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Messaging.Interfaces;
@@ -8,14 +7,14 @@ using TelnyxSharp.Messaging.Models.NumberConfigurations.Responses;
 
 namespace TelnyxSharp.Messaging.Operations.SmsMms
 {
-    public class NumberConfigurationOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class NumberConfigurationOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), INumberConfigurationOperations
     {
         // <inheritdoc />
         public async Task<ListPhoneMessageSettingsResponse?> List(
             ListPhoneMessageSettingsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("phone_numbers/messaging").AddPagination(request.PageSize);
+            var req = new TelnyxRequest("phone_numbers/messaging").AddPagination(request.PageSize);
 
             return await ExecuteAsync<ListPhoneMessageSettingsResponse>(req, cancellationToken);
         }
@@ -24,7 +23,7 @@ namespace TelnyxSharp.Messaging.Operations.SmsMms
         public async Task<RetrievePhoneMessageSettingsResponse?> Retrieve(string id,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/{id}/messaging");
+            var req = new TelnyxRequest($"phone_numbers/{id}/messaging");
 
             return await ExecuteAsync<RetrievePhoneMessageSettingsResponse>(req, cancellationToken);
         }
@@ -33,7 +32,7 @@ namespace TelnyxSharp.Messaging.Operations.SmsMms
         public async Task<UpdatePhoneNumberMessagingResponse?> Update(string id,
             UpdatePhoneNumberMessagingRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/{id}/messaging", Method.Patch);
+            var req = new TelnyxRequest($"phone_numbers/{id}/messaging", TelnyxMethod.Patch);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
@@ -44,7 +43,7 @@ namespace TelnyxSharp.Messaging.Operations.SmsMms
         public async Task<UpdateNumbersMessagingBulkResponse?> UpdateMultipleNumbers(
             UpdateNumbersMessagingBulkRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("messaging_numbers_bulk_updates", Method.Post);
+            var req = new TelnyxRequest("messaging_numbers_bulk_updates", TelnyxMethod.Post);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
@@ -55,7 +54,7 @@ namespace TelnyxSharp.Messaging.Operations.SmsMms
         public async Task<RetrieveBulkUpdateStatusResponse?> RetrieveBulkUpdateStatusAsync(string orderId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"messaging_numbers_bulk_updates/{orderId}");
+            var req = new TelnyxRequest($"messaging_numbers_bulk_updates/{orderId}");
 
             return await ExecuteAsync<RetrieveBulkUpdateStatusResponse>(req, cancellationToken);
         }

--- a/TelnyxSharp/Messaging/Operations/SmsMms/ShortCodeOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/SmsMms/ShortCodeOperations.cs
@@ -1,5 +1,4 @@
 using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Messaging.Interfaces;
@@ -8,13 +7,13 @@ using TelnyxSharp.Messaging.Models.ShortCodes.Responses;
 
 namespace TelnyxSharp.Messaging.Operations.SmsMms;
 
-public class ShortCodeOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+public class ShortCodeOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IShortCodeOperations
 {
     /// <inheritdoc />
     public async Task<ListShortCodesResponse?> List(ListShortCodesRequest request, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest("short_codes")
+        var req = new TelnyxRequest("short_codes")
             .AddPagination(request.PageSize)
             .AddFilter("filter[messaging_profile_id]", request.MessagingProfileId);
 
@@ -24,14 +23,14 @@ public class ShortCodeOperations(IRestClient client, AsyncRetryPolicy rateLimitR
     /// <inheritdoc />
     public async Task<RetrieveShortCodeResponse?> Retrieve(string shortCodeId, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest($"short_codes/{shortCodeId}");
+        var req = new TelnyxRequest($"short_codes/{shortCodeId}");
         return await ExecuteAsync<RetrieveShortCodeResponse>(req, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<UpdateShortCodeResponse?> Update(string shortCodeId, UpdateShortCodeRequest request, CancellationToken cancellationToken = default)
     {
-        var req = new RestRequest($"short_codes/{shortCodeId}", Method.Patch);
+        var req = new TelnyxRequest($"short_codes/{shortCodeId}", TelnyxMethod.Patch);
         req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
         return await ExecuteAsync<UpdateShortCodeResponse>(req, cancellationToken);

--- a/TelnyxSharp/Messaging/Operations/SmsMms/SmsMmsOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/SmsMms/SmsMmsOperations.cs
@@ -1,5 +1,4 @@
 using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Messaging.Interfaces;
 
@@ -9,7 +8,7 @@ namespace TelnyxSharp.Messaging.Operations.SmsMms
     /// Provides operations for managing SMS/MMS-related resources including messaging profiles, messages, short codes, URL domains, and number configurations.
     /// Implements the <see cref="ISmsMmsOperations"/> interface.
     /// </summary>
-    public class SmsMmsOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy) : BaseOperations(client, rateLimitRetryPolicy), ISmsMmsOperations
+    public class SmsMmsOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy) : BaseOperations(client, rateLimitRetryPolicy), ISmsMmsOperations
     {
         // Lazy initialization for various operations, ensuring thread safety and lazy loading of instances.
 

--- a/TelnyxSharp/Messaging/Operations/TenDlc/BrandOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/TenDlc/BrandOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Messaging.Interfaces;
@@ -8,14 +7,14 @@ using TelnyxSharp.Messaging.Models.Brands.Responses;
 
 namespace TelnyxSharp.Messaging.Operations.TenDlc
 {
-    public class BrandOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class BrandOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IBrandOperations
     {
         /// <inheritdoc />
         public async Task<ListBrandsResponse?> ListBrandsAsync(ListBrandsRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/brand")
+            var req = new TelnyxRequest($"10dlc/brand")
                 .AddFilter("recordsPerPage", request.PageSize)
                 .AddFilter("sort", request.Sort)
                 .AddFilter("displayName", request.DisplayName)
@@ -32,7 +31,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<CreateBrandResponse?> Create(CreateBrandRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("10dlc/brand", Method.Post);
+            var req = new TelnyxRequest("10dlc/brand", TelnyxMethod.Post);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
@@ -43,7 +42,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<GetBrandResponse?> Retrieve(string brandId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/brand/{brandId}");
+            var req = new TelnyxRequest($"10dlc/brand/{brandId}");
 
             return await ExecuteAsync<GetBrandResponse>(req, cancellationToken);
         }
@@ -52,7 +51,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<UpdateBrandResponse?> Update(string brandId, UpdateBrandRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/brand/{brandId}", Method.Put);
+            var req = new TelnyxRequest($"10dlc/brand/{brandId}", TelnyxMethod.Put);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
@@ -63,7 +62,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<DeleteBrandResponse?> Delete(string brandId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/brand/{brandId}", Method.Delete);
+            var req = new TelnyxRequest($"10dlc/brand/{brandId}", TelnyxMethod.Delete);
 
             return await ExecuteAsync<DeleteBrandResponse>(req, cancellationToken);
         }
@@ -72,7 +71,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<ResendBrand2FAEmailResponse?> Resend2FAEmailAsync(string brandId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/brand/{brandId}/2faEmail", Method.Post);
+            var req = new TelnyxRequest($"10dlc/brand/{brandId}/2faEmail", TelnyxMethod.Post);
 
             return await ExecuteAsync<ResendBrand2FAEmailResponse>(req, cancellationToken);
         }
@@ -81,7 +80,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<RevetBrandResponse?> Revet(string brandId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/brand/{brandId}/revet", Method.Put);
+            var req = new TelnyxRequest($"10dlc/brand/{brandId}/revet", TelnyxMethod.Put);
 
             return await ExecuteAsync<RevetBrandResponse>(req, cancellationToken);
         }
@@ -90,7 +89,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<ListExternalVettingResponse?> ListExternalVetting(string brandId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/brand/{brandId}/externalVetting");
+            var req = new TelnyxRequest($"10dlc/brand/{brandId}/externalVetting");
 
             return await ExecuteAsync<ListExternalVettingResponse>(req, cancellationToken);
         }
@@ -99,7 +98,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<ImportExternalVettingResponse?> ImportExternalVettingRecord(string brandId,
             ImportExternalVettingRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/brand/{brandId}/externalVetting", Method.Put);
+            var req = new TelnyxRequest($"10dlc/brand/{brandId}/externalVetting", TelnyxMethod.Put);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
@@ -110,7 +109,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<OrderExternalVettingResponse?> OrderExternalVetting(string brandId,
             OrderExternalVettingRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/brand/{brandId}/externalVetting", Method.Post);
+            var req = new TelnyxRequest($"10dlc/brand/{brandId}/externalVetting", TelnyxMethod.Post);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
@@ -121,7 +120,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<GetBrandFeedbackResponse?> GetFeedback(string brandId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/brand/feedback/{brandId}");
+            var req = new TelnyxRequest($"10dlc/brand/feedback/{brandId}");
 
             return await ExecuteAsync<GetBrandFeedbackResponse>(req, cancellationToken);
         }

--- a/TelnyxSharp/Messaging/Operations/TenDlc/BulkPhoneNumberCampaignOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/TenDlc/BulkPhoneNumberCampaignOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Messaging.Interfaces;
@@ -8,14 +7,14 @@ using TelnyxSharp.Messaging.Models.BulkPhoneNumberCampaign.Responses;
 
 namespace TelnyxSharp.Messaging.Operations.TenDlc
 {
-    public class BulkPhoneNumberCampaignOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class BulkPhoneNumberCampaignOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IBulkPhoneNumberCampaignOperations
     {
         /// <inheritdoc />
         public async Task<AssignMessagingProfileToCampaignResponse?> AssignMessagingProfile(
             AssignMessagingProfileToCampaignRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("10dlc/phoneNumberAssignmentByProfile", Method.Post);
+            var req = new TelnyxRequest("10dlc/phoneNumberAssignmentByProfile", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<AssignMessagingProfileToCampaignResponse>(req, cancellationToken);
@@ -25,7 +24,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<GetAssignmentTaskStatusResponse?> GetAssignmentTaskStatus(string taskId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/phoneNumberAssignmentByProfile/{taskId}");
+            var req = new TelnyxRequest($"10dlc/phoneNumberAssignmentByProfile/{taskId}");
 
             return await ExecuteAsync<GetAssignmentTaskStatusResponse>(req, cancellationToken);
         }
@@ -35,7 +34,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
             GetPhoneNumberStatusRequest request, CancellationToken cancellationToken = default)
         {
             var req =
-                new RestRequest($"10dlc/phoneNumberAssignmentByProfile/{taskId}/phoneNumbers")
+                new TelnyxRequest($"10dlc/phoneNumberAssignmentByProfile/{taskId}/phoneNumbers")
                 .AddFilter("recordsPerPage", request.PageSize);
 
             return await ExecuteAsync<GetPhoneNumberStatusResponse>(req, cancellationToken);

--- a/TelnyxSharp/Messaging/Operations/TenDlc/CampaignOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/TenDlc/CampaignOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Messaging.Interfaces;
@@ -8,14 +7,14 @@ using TelnyxSharp.Messaging.Models.Campaign.Responses;
 
 namespace TelnyxSharp.Messaging.Operations.TenDlc
 {
-    public class CampaignOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class CampaignOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), ICampaignOperations
     {
         // <inheritdoc />
         public async Task<ListCampaignsResponse?> List(ListCampaignsRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/campaign")
+            var req = new TelnyxRequest($"10dlc/campaign")
                 .AddFilter("recordsPerPage", request.PageSize)
                 .AddFilter("sort", request.Sort)
                 .AddFilter("brandId", request.BrandId);
@@ -26,7 +25,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<GetCampaignResponse?> Get(string campaignId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/campaign/{campaignId}");
+            var req = new TelnyxRequest($"10dlc/campaign/{campaignId}");
 
             return await ExecuteAsync<GetCampaignResponse>(req, cancellationToken);
         }
@@ -35,7 +34,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<UpdateCampaignResponse?> Update(string campaignId, UpdateCampaignRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/campaign/{campaignId}", Method.Put);
+            var req = new TelnyxRequest($"10dlc/campaign/{campaignId}", TelnyxMethod.Put);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
@@ -46,7 +45,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<DeactivateCampaignResponse?> Deactivate(string campaignId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/campaign/{campaignId}", Method.Delete);
+            var req = new TelnyxRequest($"10dlc/campaign/{campaignId}", TelnyxMethod.Delete);
 
             return await ExecuteAsync<DeactivateCampaignResponse>(req, cancellationToken);
         }
@@ -55,7 +54,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<GetCampaignOperationStatusResponse?> RetrieveOperationStatus(string campaignId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/campaign/{campaignId}/operationStatus");
+            var req = new TelnyxRequest($"10dlc/campaign/{campaignId}/operationStatus");
 
             return await ExecuteAsync<GetCampaignOperationStatusResponse>(req, cancellationToken);
         }
@@ -64,7 +63,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<GetCampaignOsrAttributesResponse?> RetrieveOsrAttributes(string campaignId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/campaign/{campaignId}/osr/attributes");
+            var req = new TelnyxRequest($"10dlc/campaign/{campaignId}/osr/attributes");
 
             return await ExecuteAsync<GetCampaignOsrAttributesResponse>(req, cancellationToken);
         }
@@ -73,7 +72,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<GetCampaignCostResponse?> GetCost(GetCampaignCostRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/campaign/usecase/cost").AddFilter("usecase", request.UseCase);
+            var req = new TelnyxRequest($"10dlc/campaign/usecase/cost").AddFilter("usecase", request.UseCase);
 
             return await ExecuteAsync<GetCampaignCostResponse>(req, cancellationToken);
         }
@@ -82,7 +81,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<SubmitCampaignResponse?> Submit(SubmitCampaignRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("10dlc/campaignBuilder", Method.Post);
+            var req = new TelnyxRequest("10dlc/campaignBuilder", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<SubmitCampaignResponse>(req, cancellationToken);
@@ -92,7 +91,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<QualifyCampaignByUsecaseResponse?> QualifyByUsecase(string brandId,
             string usecase, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/campaignBuilder/brand/{brandId}/usecase/{usecase}");
+            var req = new TelnyxRequest($"10dlc/campaignBuilder/brand/{brandId}/usecase/{usecase}");
 
             return await ExecuteAsync<QualifyCampaignByUsecaseResponse>(req, cancellationToken);
         }
@@ -101,7 +100,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<GetCampaignMnoMetadataResponse?> GetCampaignMnoMetadataAsync(string campaignId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/campaign/{campaignId}/mnoMetadata");
+            var req = new TelnyxRequest($"10dlc/campaign/{campaignId}/mnoMetadata");
 
             return await ExecuteAsync<GetCampaignMnoMetadataResponse>(req, cancellationToken);
         }
@@ -109,7 +108,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         /// <inheritdoc />
         public async Task<AcceptSharedCampaignResponse?> AcceptSharedCampaignAsync(string campaignId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/campaign/acceptSharing/{campaignId}", Method.Post);
+            var req = new TelnyxRequest($"10dlc/campaign/acceptSharing/{campaignId}", TelnyxMethod.Post);
 
             return await ExecuteAsync<AcceptSharedCampaignResponse>(req, cancellationToken);
         }
@@ -118,7 +117,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<GetCampaignSharingStatusResponse?> GetSharingStatus(string campaignId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/campaign/{campaignId}/sharing");
+            var req = new TelnyxRequest($"10dlc/campaign/{campaignId}/sharing");
 
             return await ExecuteAsync<GetCampaignSharingStatusResponse>(req, cancellationToken);
         }

--- a/TelnyxSharp/Messaging/Operations/TenDlc/EnumOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/TenDlc/EnumOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Enums;
 using TelnyxSharp.Messaging.Interfaces;
@@ -7,14 +6,14 @@ using TelnyxSharp.Messaging.Models.Enums.Responses;
 
 namespace TelnyxSharp.Messaging.Operations.TenDlc
 {
-    public class EnumOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class EnumOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IEnumOperations
     {
         /// <inheritdoc />
         public async Task<GetEnumResponse?> Get(EnumEndpoint endpoint,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/enum/{endpoint.ToString().ToLower()}");
+            var req = new TelnyxRequest($"10dlc/enum/{endpoint.ToString().ToLower()}");
 
             return await ExecuteAsync<GetEnumResponse>(req, cancellationToken);
         }

--- a/TelnyxSharp/Messaging/Operations/TenDlc/PhoneNumberCampaignOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/TenDlc/PhoneNumberCampaignOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Messaging.Interfaces;
@@ -8,14 +7,14 @@ using TelnyxSharp.Messaging.Models.PhoneNumberCampaign.Responses;
 
 namespace TelnyxSharp.Messaging.Operations.TenDlc
 {
-    public class PhoneNumberCampaignOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class PhoneNumberCampaignOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IPhoneNumberCampaignOperations
     {
         /// <inheritdoc />
         public async Task<RetrievePhoneNumberCampaignsResponse?> Retrieve(
             RetrievePhoneNumberCampaignsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("10dlc/phone_number_campaigns")
+            var req = new TelnyxRequest("10dlc/phone_number_campaigns")
                 .AddFilter("filter[telnyx_campaign_id]", request.FilterTelnyxCampaignId)
                 .AddFilter("filter[telnyx_brand_id]", request.FilterTelnyxBrandId)
                 .AddFilter("filter[tcr_campaign_id]", request.FilterTcrCampaignId)
@@ -30,7 +29,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<CreatePhoneNumberCampaignResponse?> Create(
             CreatePhoneNumberCampaignRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("10dlc/phone_number_campaigns", Method.Post);
+            var req = new TelnyxRequest("10dlc/phone_number_campaigns", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CreatePhoneNumberCampaignResponse>(req, cancellationToken);
@@ -40,7 +39,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<GetPhoneNumberCampaignResponse?> Get(string phoneNumber,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/phone_number_campaigns/{phoneNumber}");
+            var req = new TelnyxRequest($"10dlc/phone_number_campaigns/{phoneNumber}");
 
             return await ExecuteAsync<GetPhoneNumberCampaignResponse>(req, cancellationToken);
         }
@@ -49,7 +48,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<UpdatePhoneNumberCampaignResponse?> Update(string phoneNumber,
             UpdatePhoneNumberCampaignRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/phone_number_campaigns/{phoneNumber}", Method.Put);
+            var req = new TelnyxRequest($"10dlc/phone_number_campaigns/{phoneNumber}", TelnyxMethod.Put);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
@@ -60,7 +59,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<DeletePhoneNumberCampaignResponse?> Delete(string phoneNumber,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/phone_number_campaigns/{phoneNumber}", Method.Delete);
+            var req = new TelnyxRequest($"10dlc/phone_number_campaigns/{phoneNumber}", TelnyxMethod.Delete);
 
             return await ExecuteAsync<DeletePhoneNumberCampaignResponse>(req, cancellationToken);
         }

--- a/TelnyxSharp/Messaging/Operations/TenDlc/SharedCampaignOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/TenDlc/SharedCampaignOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Messaging.Interfaces;
@@ -8,14 +7,14 @@ using TelnyxSharp.Messaging.Models.SharedCampaign.Responses;
 
 namespace TelnyxSharp.Messaging.Operations.TenDlc
 {
-    public class SharedCampaignOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class SharedCampaignOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), ISharedCampaignOperations
     {
         /// <inheritdoc />
         public async Task<ListSharedCampaignsResponse?> List(ListSharedCampaignsRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/partner_campaigns")
+            var req = new TelnyxRequest($"10dlc/partner_campaigns")
                 .AddFilter("recordsPerPage", request.PageSize)
                 .AddFilter("sort", request.Sort);
 
@@ -26,7 +25,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<GetSharedCampaignRecordResponse?> Get(string campaignId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/partner_campaigns/{campaignId}");
+            var req = new TelnyxRequest($"10dlc/partner_campaigns/{campaignId}");
 
             return await ExecuteAsync<GetSharedCampaignRecordResponse>(req, cancellationToken);
         }
@@ -35,7 +34,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<UpdateSingleSharedCampaignResponse?> Update(string campaignId,
             UpdateSingleSharedCampaignRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/partner_campaigns/{campaignId}", Method.Patch);
+            var req = new TelnyxRequest($"10dlc/partner_campaigns/{campaignId}", TelnyxMethod.Patch);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<UpdateSingleSharedCampaignResponse>(req, cancellationToken);
@@ -45,7 +44,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<GetSharingStatusResponse?> GetSharingStatus(string campaignId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/partnerCampaign/{campaignId}/sharing");
+            var req = new TelnyxRequest($"10dlc/partnerCampaign/{campaignId}/sharing");
 
             return await ExecuteAsync<GetSharingStatusResponse>(req, cancellationToken);
         }
@@ -54,7 +53,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
         public async Task<GetPartnerCampaignsSharedByUserResponse?> GetPartnerCampaignsSharedByUser(
             GetPartnerCampaignsSharedByUserRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"10dlc/partnerCampaign/sharedByMe").AddFilter("recordsPerPage", request.PageSize);
+            var req = new TelnyxRequest($"10dlc/partnerCampaign/sharedByMe").AddFilter("recordsPerPage", request.PageSize);
             return await ExecuteAsync<GetPartnerCampaignsSharedByUserResponse>(req, cancellationToken);
         }
     }

--- a/TelnyxSharp/Messaging/Operations/TenDlc/TenDlcOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/TenDlc/TenDlcOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Messaging.Interfaces;
 
@@ -9,7 +8,7 @@ namespace TelnyxSharp.Messaging.Operations.TenDlc
     /// Provides operations related to TenDLC (10-Digit Long Code) messaging campaigns.
     /// This includes managing campaigns, phone number campaigns, bulk phone number campaigns, shared campaigns, and ENUM operations.
     /// </summary>
-    public class TenDlcOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy) : BaseOperations(client, rateLimitRetryPolicy), ITenDlcOperations
+    public class TenDlcOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy) : BaseOperations(client, rateLimitRetryPolicy), ITenDlcOperations
     {
         private readonly Lazy<IBrandOperations> _brandOperations = new(() =>
             new BrandOperations(client, rateLimitRetryPolicy), LazyThreadSafetyMode.ExecutionAndPublication);

--- a/TelnyxSharp/Messaging/Operations/TollFreeVerification/TollFreeOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/TollFreeVerification/TollFreeOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Messaging.Interfaces;
 
@@ -8,7 +7,7 @@ namespace TelnyxSharp.Messaging.Operations.TollFreeVerification
     /// <summary>
     /// Provides operations related to managing toll-free numbers, including toll-free verification.
     /// </summary>
-    public class TollFreeOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class TollFreeOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), ITollFreeOperations
     {
         private readonly Lazy<ITollFreeVerificationOperations> _verificationOperations = new(() =>

--- a/TelnyxSharp/Messaging/Operations/TollFreeVerification/TollFreeVerificationOperations.cs
+++ b/TelnyxSharp/Messaging/Operations/TollFreeVerification/TollFreeVerificationOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Messaging.Interfaces;
@@ -8,14 +7,14 @@ using TelnyxSharp.Messaging.Models.TollFreeVerificationOperations.Responses;
 
 namespace TelnyxSharp.Messaging.Operations.TollFreeVerification
 {
-    public class TollFreeVerificationOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class TollFreeVerificationOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), ITollFreeVerificationOperations
     {
         /// <inheritdoc />
         public async Task<ListVerificationRequestsResponse?> List(
             ListVerificationRequestsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"messaging_tollfree/verification/requests")
+            var req = new TelnyxRequest($"messaging_tollfree/verification/requests")
                 .AddFilter("page_size", request.PageSize)
                 .AddFilter("date_start", request.DateStart?.ToString("yyyy-MM-ddTHH:mm:ss.ffffffzzz"))
                 .AddFilter("date_end", request.DateEnd?.ToString("yyyy-MM-ddTHH:mm:ss.ffffffzzz"))
@@ -29,7 +28,7 @@ namespace TelnyxSharp.Messaging.Operations.TollFreeVerification
         public async Task<SubmitVerificationRequestResponse?> Submit(
             SubmitVerificationRequestRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("messaging_tollfree/verification/requests", Method.Post);
+            var req = new TelnyxRequest("messaging_tollfree/verification/requests", TelnyxMethod.Post);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
@@ -40,7 +39,7 @@ namespace TelnyxSharp.Messaging.Operations.TollFreeVerification
         public async Task<GetVerificationRequestResponse?> Retrieve(string id,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"messaging_tollfree/verification/requests/{id}");
+            var req = new TelnyxRequest($"messaging_tollfree/verification/requests/{id}");
 
             return await ExecuteAsync<GetVerificationRequestResponse>(req, cancellationToken);
         }
@@ -49,7 +48,7 @@ namespace TelnyxSharp.Messaging.Operations.TollFreeVerification
         public async Task<DeleteVerificationRequestResponse?> Delete(string id,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"messaging_tollfree/verification/requests/{id}", Method.Delete);
+            var req = new TelnyxRequest($"messaging_tollfree/verification/requests/{id}", TelnyxMethod.Delete);
 
             return await ExecuteAsync<DeleteVerificationRequestResponse>(req, cancellationToken);
         }
@@ -58,7 +57,7 @@ namespace TelnyxSharp.Messaging.Operations.TollFreeVerification
         public async Task<UpdateVerificationRequestResponse?> Update(string id,
             UpdateVerificationRequestRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"messaging_tollfree/verification/requests/{id}", Method.Patch);
+            var req = new TelnyxRequest($"messaging_tollfree/verification/requests/{id}", TelnyxMethod.Patch);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 

--- a/TelnyxSharp/Numbers/Operations/Numbers/ChannelZones/ChannelZonesOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/ChannelZones/ChannelZonesOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
@@ -8,7 +7,7 @@ using TelnyxSharp.Numbers.Models.ChannelZones.Responses;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.ChannelZones
 {
-    public class ChannelZonesOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class ChannelZonesOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IChannelZonesOperations
     {
         /// <inheritdoc />
@@ -16,7 +15,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.ChannelZones
            CancellationToken cancellationToken = default)
         {
 
-            var req = new RestRequest("phone_numbers/channel_zones")
+            var req = new TelnyxRequest("phone_numbers/channel_zones")
                             .AddPagination(request.PageSize);
 
             return await ExecuteAsync<ListChannelZonesResponse>(req, cancellationToken);
@@ -26,7 +25,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.ChannelZones
         public async Task<GetChannelZonesResponse> Get(string channelZoneId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/channel_zones/{channelZoneId}");
+            var req = new TelnyxRequest($"phone_numbers/channel_zones/{channelZoneId}");
             return await ExecuteAsync<GetChannelZonesResponse>(req, cancellationToken);
         }
 
@@ -34,7 +33,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.ChannelZones
         public async Task<UpdateChannelZoneResponse> Update(string channelZoneId, UpdateChannelZoneRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/channel_zones/{channelZoneId}", Method.Patch);
+            var req = new TelnyxRequest($"phone_numbers/channel_zones/{channelZoneId}", TelnyxMethod.Patch);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<UpdateChannelZoneResponse>(req, cancellationToken);
@@ -44,7 +43,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.ChannelZones
         public async Task<GetChannelZonePhoneNumbersResponse> ListPhoneNumbers(string channelZoneId, GetChannelZonePhoneNumbersRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/channel_zones/{channelZoneId}/channel_zone_phone_numbers")
+            var req = new TelnyxRequest($"phone_numbers/channel_zones/{channelZoneId}/channel_zone_phone_numbers")
                                 .AddPagination(request.PageSize);
 
             return await ExecuteAsync<GetChannelZonePhoneNumbersResponse>(req, cancellationToken);
@@ -54,7 +53,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.ChannelZones
         public async Task<AssignPhoneNumberToChannelZoneResponse> AssignPhoneNumber(string channelZoneId, AssignPhoneNumberToChannelZoneRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/channel_zones/{channelZoneId}/channel_zone_phone_numbers", Method.Post);
+            var req = new TelnyxRequest($"phone_numbers/channel_zones/{channelZoneId}/channel_zone_phone_numbers", TelnyxMethod.Post);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<AssignPhoneNumberToChannelZoneResponse>(req, cancellationToken);
@@ -64,7 +63,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.ChannelZones
         public async Task<UnassignPhoneNumberResponse> UnassignPhoneNumber(string channelZoneId, string phoneNumber,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/channel_zones/{channelZoneId}/channel_zone_phone_numbers/{phoneNumber}", Method.Delete);
+            var req = new TelnyxRequest($"phone_numbers/channel_zones/{channelZoneId}/channel_zone_phone_numbers/{phoneNumber}", TelnyxMethod.Delete);
 
             return await ExecuteAsync<UnassignPhoneNumberResponse>(req, cancellationToken);
         }

--- a/TelnyxSharp/Numbers/Operations/Numbers/Documents/DocumentOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/Documents/DocumentOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
@@ -9,14 +8,14 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.Documents;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.Documents
 {
-    public class DocumentOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class DocumentOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IDocumentOperations
     {
         /// <inheritdoc />
         public async Task<ListDocumentsResponse> List(ListDocumentsRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("documents")
+            var req = new TelnyxRequest("documents")
                 .AddFilter("filter[filename][contains]", request.FilenameContains)
                 .AddFilter("filter[customer_reference][eq]", request.CustomerReference)
                 .AddFilter("filter[customer_reference][in][]", request.CustomerReferences)
@@ -31,7 +30,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.Documents
         /// <inheritdoc />
         public async Task<UploadDocumentResponse> Upload(UploadDocumentRequest request, string fileName, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("documents", Method.Post)
+            var req = new TelnyxRequest("documents", TelnyxMethod.Post)
                 .AddFile("file", request.File, fileName)
                 .AddParameter("customer_reference", request.CustomerReference)
                 .AddHeader("Content-Type", "multipart/form-data");
@@ -42,14 +41,14 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.Documents
         /// <inheritdoc />
         public async Task<GetDocumentResponse> Get(string documentId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"documents/{documentId}");
+            var req = new TelnyxRequest($"documents/{documentId}");
             return await ExecuteAsync<GetDocumentResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<DeleteDocumentResponse> Delete(string documentId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"documents/{documentId}", Method.Delete);
+            var req = new TelnyxRequest($"documents/{documentId}", TelnyxMethod.Delete);
             return await ExecuteAsync<DeleteDocumentResponse>(req, cancellationToken);
         }
 
@@ -57,7 +56,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.Documents
         public async Task<UpdateDocumentResponse> Update(string id, UpdateDocumentRequest request,
            CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"documents/{id}", Method.Patch);
+            var req = new TelnyxRequest($"documents/{id}", TelnyxMethod.Patch);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<UpdateDocumentResponse>(req, cancellationToken);
         }
@@ -65,7 +64,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.Documents
         /// <inheritdoc />
         public async Task<DownloadDocumentResponse> Download(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"documents/{id}/dowload", Method.Patch);
+            var req = new TelnyxRequest($"documents/{id}/dowload", TelnyxMethod.Patch);
             return await ExecuteAsync<DownloadDocumentResponse>(req, cancellationToken);
         }
 
@@ -73,7 +72,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.Documents
         public async Task<ListDocumentLinksResponse> ListDocumentLinks(ListDocumentLinksRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("document_links")
+            var req = new TelnyxRequest("document_links")
                 .AddPagination(request.PageSize)
                 .AddFilter("filter[document_id]", request.DocumentId)
                 .AddFilter("filter[linked_record_type]", request.LinkedRecordType)

--- a/TelnyxSharp/Numbers/Operations/Numbers/Documents/DocumentsOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/Documents/DocumentsOperations.cs
@@ -1,11 +1,10 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.Documents
 {
-    public class DocumentsOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class DocumentsOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IDocumentsOperations
     {
         private readonly Lazy<IDocumentOperations> _documentOperations = new(() =>

--- a/TelnyxSharp/Numbers/Operations/Numbers/Documents/RequirementTypesOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/Documents/RequirementTypesOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.RequirementTypes;
@@ -7,14 +6,14 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.RequirementTypes;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.Documents
 {
-    public class RequirementTypesOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class RequirementTypesOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IRequirementTypesOperations
     {
         /// <inheritdoc />
         public async Task<ListRequirementTypesResponse> List(ListRequirementTypesRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("requirement_types")
+            var req = new TelnyxRequest("requirement_types")
                           .AddFilter("filter[name][contains]", request.NameContains)
                           .AddFilter("sort[]", request.Sort);
 
@@ -24,7 +23,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.Documents
         /// <inheritdoc />
         public async Task<RetrieveRequirementTypeResponse> Get(string requirementTypeId, CancellationToken cancellationToken = default)
         {
-            var request = new RestRequest($"requirement_types/{requirementTypeId}");
+            var request = new TelnyxRequest($"requirement_types/{requirementTypeId}");
 
             return await ExecuteAsync<RetrieveRequirementTypeResponse>(request, cancellationToken);
         }

--- a/TelnyxSharp/Numbers/Operations/Numbers/Documents/RequirementsOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/Documents/RequirementsOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.Requirements;
@@ -8,13 +7,13 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.Requirements;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.Documents
 {
-    public class RequirementsOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class RequirementsOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IRequirementsOperations
     {
         /// <inheritdoc />
         public async Task<ListRequirementResponse> List(ListRequirementsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("requirements")
+            var req = new TelnyxRequest("requirements")
                         .AddFilter("filter[country_code]", request.CountryCode)
                         .AddFilter("filter[phone_number_type]", request.PhoneNumberType)
                         .AddFilter("filter[action]", request.Action)
@@ -27,7 +26,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.Documents
         /// <inheritdoc />
         public async Task<RetrieveDocumentRequirementResponse> Retrieve(string requirementId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"requirements/{requirementId}");
+            var req = new TelnyxRequest($"requirements/{requirementId}");
 
             return await ExecuteAsync<RetrieveDocumentRequirementResponse>(req, cancellationToken);
         }

--- a/TelnyxSharp/Numbers/Operations/Numbers/InboundChannels/InboundChannelsOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/InboundChannels/InboundChannelsOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
@@ -8,14 +7,14 @@ using TelnyxSharp.Numbers.Models.InboundChannels.Responses;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.InboundChannels
 {
-    internal class InboundChannelsOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    internal class InboundChannelsOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IInboundChannelsOperations
     {
 
         /// <inheritdoc />
         public async Task<ListInboundChannelsResponse> List(CancellationToken cancellationToken = default)
         {
-            var request = new RestRequest("phone_numbers/inbound_channels");
+            var request = new TelnyxRequest("phone_numbers/inbound_channels");
 
             return await ExecuteAsync<ListInboundChannelsResponse>(request, cancellationToken);
         }
@@ -24,7 +23,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.InboundChannels
         public async Task<UpdateInboundChannelsResponse> Update(UpdateInboundChannelsRequest request,
            CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("phone_numbers/inbound_channels", Method.Patch);
+            var req = new TelnyxRequest("phone_numbers/inbound_channels", TelnyxMethod.Patch);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<UpdateInboundChannelsResponse>(req, cancellationToken);

--- a/TelnyxSharp/Numbers/Operations/Numbers/NumberPortout/NumberPortoutOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/NumberPortout/NumberPortoutOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
@@ -8,14 +7,14 @@ using TelnyxSharp.Numbers.Models.NumberPortout.Responses;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.NumberPortout
 {
-    public class NumberPortoutOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class NumberPortoutOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), INumberPortoutOperations
     {
         /// <inheritdoc />
         public async Task<ListPortoutResponse> List(ListPortoutRequest request,
             CancellationToken cancellationToken = default)
         {
-            var restRequest = new RestRequest("portouts")
+            var restRequest = new TelnyxRequest("portouts")
                 .AddFilter("filter[carrier_name]", request.CarrierName)
                 .AddFilter("filter[spid]", request.Spid)
                 .AddFilter("filter[status]", request.Status)
@@ -37,7 +36,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.NumberPortout
         public async Task<GetPortoutResponse> Get(string portoutId,
             CancellationToken cancellationToken = default)
         {
-            var restRequest = new RestRequest($"portouts/{portoutId}");
+            var restRequest = new TelnyxRequest($"portouts/{portoutId}");
             return await ExecuteAsync<GetPortoutResponse>(restRequest, cancellationToken);
         }
 
@@ -45,7 +44,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.NumberPortout
         public async Task<UpdatePortoutStatusResponse> UpdateStatus(string portoutId, string status, UpdatePortoutStatusRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"portouts/{portoutId}/{status}", Method.Patch);
+            var req = new TelnyxRequest($"portouts/{portoutId}/{status}", TelnyxMethod.Patch);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<UpdatePortoutStatusResponse>(req, cancellationToken);
@@ -55,7 +54,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.NumberPortout
         public async Task<PortoutCommentsResponse> ListPortoutComments(string portoutId,
             CancellationToken cancellationToken = default)
         {
-            var restRequest = new RestRequest($"portouts/{portoutId}/comments");
+            var restRequest = new TelnyxRequest($"portouts/{portoutId}/comments");
             return await ExecuteAsync<PortoutCommentsResponse>(restRequest, cancellationToken);
         }
 
@@ -63,7 +62,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.NumberPortout
         public async Task<CreatePortoutCommentResponse> CreatePortoutComments(string portoutId, CreatePortoutCommentRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"portouts/{portoutId}/comments", Method.Post);
+            var req = new TelnyxRequest($"portouts/{portoutId}/comments", TelnyxMethod.Post);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CreatePortoutCommentResponse>(req, cancellationToken);
@@ -73,7 +72,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.NumberPortout
         public async Task<ListPortoutSupportingDocumentsResponse> ListSupportingDocuments(string portoutId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"portouts/{portoutId}/supporting_documents");
+            var req = new TelnyxRequest($"portouts/{portoutId}/supporting_documents");
 
             return await ExecuteAsync<ListPortoutSupportingDocumentsResponse>(req, cancellationToken);
         }
@@ -82,7 +81,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.NumberPortout
         public async Task<CreatePortoutSupportingDocumentsResponse> CreateSupportingDocuments(string portoutId, CreatePortoutSupportingDocumentsRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"portouts/{portoutId}/supporting_documents", Method.Post);
+            var req = new TelnyxRequest($"portouts/{portoutId}/supporting_documents", TelnyxMethod.Post);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CreatePortoutSupportingDocumentsResponse>(req, cancellationToken);
@@ -92,7 +91,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.NumberPortout
         public async Task<ListPortoutReportsResponse> ListPortoutReports(ListPortoutReportsRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("portouts/reports")
+            var req = new TelnyxRequest("portouts/reports")
                             .AddFilter("filter[report_type]", request.ReportType)
                             .AddFilter("filter[status]", request.Status)
                             .AddPagination(request.PageSize);
@@ -104,7 +103,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.NumberPortout
         public async Task<CreatePortoutReportResponse> CreatePortoutReports(CreatePortoutReportRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("portouts/reports", Method.Post);
+            var req = new TelnyxRequest("portouts/reports", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CreatePortoutReportResponse>(req, cancellationToken);
@@ -114,7 +113,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.NumberPortout
         public async Task<GetPortoutReportResponse> GetPortoutReports(string reportId,
            CancellationToken cancellationToken = default)
         {
-            var restRequest = new RestRequest($"portouts/reports/{reportId}");
+            var restRequest = new TelnyxRequest($"portouts/reports/{reportId}");
 
             return await ExecuteAsync<GetPortoutReportResponse>(restRequest, cancellationToken);
         }
@@ -123,7 +122,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.NumberPortout
         public async Task<ListPortoutRejectionCodesResponse> ListRejectionCodes(string portoutId, ListPortoutRejectionCodesRequest request,
                 CancellationToken cancellationToken = default)
         {
-            var restRequest = new RestRequest($"portouts/rejections/{portoutId}")
+            var restRequest = new TelnyxRequest($"portouts/rejections/{portoutId}")
                 .AddFilter("filter[code]", request?.Code)
                 .AddFilter("filter[code][in]", request?.CodesIn);
 
@@ -134,7 +133,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.NumberPortout
         public async Task<ListPortoutEventsResponse> ListEvent(ListPortoutEventsRequest request,
           CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("portouts/events")
+            var req = new TelnyxRequest("portouts/events")
                 .AddFilter("filter[event_type]", request.EventType)
                 .AddFilter("filter[portout_id]", request.PortoutId)
                 .AddPagination(request.PageSize)
@@ -148,7 +147,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.NumberPortout
         public async Task<GetPortoutEventResponse> GetEvent(string eventId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"portouts/events/{eventId}");
+            var req = new TelnyxRequest($"portouts/events/{eventId}");
             return await ExecuteAsync<GetPortoutEventResponse>(req, cancellationToken);
         }
 
@@ -156,7 +155,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.NumberPortout
         public async Task<RepublishPortoutEventResponse> RepublishEvent(string eventId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"portouts/events/{eventId}/republish");
+            var req = new TelnyxRequest($"portouts/events/{eventId}/republish");
             return await ExecuteAsync<RepublishPortoutEventResponse>(req, cancellationToken);
         }
     }

--- a/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumberPorting/PhoneNumberPortingOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumberPorting/PhoneNumberPortingOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
@@ -8,14 +7,14 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.PhoneNumberPorting;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumberPorting
 {
-    public class PhoneNumberPortingOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class PhoneNumberPortingOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IPhoneNumberPortingOperations
     {
         /// <inheritdoc />
         public async Task<PortabilityCheckResponse> RunPortabilityCheck(PortabilityCheckRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("portability_checks", Method.Post);
+            var req = new TelnyxRequest("portability_checks", TelnyxMethod.Post);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<PortabilityCheckResponse>(req, cancellationToken);

--- a/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/AdvancedNumberOrdersOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/AdvancedNumberOrdersOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
@@ -8,14 +7,14 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.AdvancedNumberOrders;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
 {
-    public class AdvancedNumberOrdersOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class AdvancedNumberOrdersOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IAdvancedNumberOrdersOperations
     {
 
         /// <inheritdoc />
         public async Task<CreateAdvancedOrderResponse> Create(CreateAdvancedOrderRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("advanced_orders", Method.Post);
+            var req = new TelnyxRequest("advanced_orders", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CreateAdvancedOrderResponse>(req, cancellationToken);
@@ -24,7 +23,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<ListAdvancedOrdersResponse> List(CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("advanced_orders");
+            var req = new TelnyxRequest("advanced_orders");
 
             return await ExecuteAsync<ListAdvancedOrdersResponse>(req, cancellationToken);
         }
@@ -32,7 +31,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<GetAdvancedOrderResponse> Get(string orderId, CancellationToken cancellationToken = default)
         {
-            var restRequest = new RestRequest($"advanced_orders/{orderId}");
+            var restRequest = new TelnyxRequest($"advanced_orders/{orderId}");
             return await ExecuteAsync<GetAdvancedOrderResponse>(restRequest, cancellationToken);
         }
     }

--- a/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/BulkPhoneNumberOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/BulkPhoneNumberOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
@@ -8,13 +7,13 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.BulkPhoneNumberOperation
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
 {
-    public class BulkPhoneNumberOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class BulkPhoneNumberOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IBulkPhoneNumberOperations
     {
         /// <inheritdoc />
         public async Task<ListNumbersJobsResponse> ListPhoneNumbersJobs(ListNumbersJobsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("phone_numbers/jobs")
+            var req = new TelnyxRequest("phone_numbers/jobs")
                 .AddFilter("filter[type]", request.Type)
                 .AddPagination(request.PageSize)
                 .AddFilter("sort", request.Sort);
@@ -25,7 +24,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<RetrieveNumbersJobResponse> GetPhoneNumbersJob(string jobId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/jobs/{jobId}");
+            var req = new TelnyxRequest($"phone_numbers/jobs/{jobId}");
             return await ExecuteAsync<RetrieveNumbersJobResponse>(req, cancellationToken);
         }
 
@@ -33,7 +32,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<UpdateEmergencySettingsResponse> UpdateEmergencySettings(UpdateEmergencySettingsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("phone_numbers/jobs/update_emergency_settings", Method.Post);
+            var req = new TelnyxRequest("phone_numbers/jobs/update_emergency_settings", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<UpdateEmergencySettingsResponse>(req, cancellationToken);
         }
@@ -41,7 +40,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<UpdateNumbersBatchResponse> UpdateNumbersBatch(UpdateNumbersBatchRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("phone_numbers/jobs/update_phone_numbers", Method.Post);
+            var req = new TelnyxRequest("phone_numbers/jobs/update_phone_numbers", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<UpdateNumbersBatchResponse>(req, cancellationToken);
         }
@@ -49,7 +48,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<DeleteNumbersBatchResponse> DeleteNumbersBatch(DeleteNumbersBatchRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("phone_numbers/jobs/delete_phone_numbers", Method.Post);
+            var req = new TelnyxRequest("phone_numbers/jobs/delete_phone_numbers", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<DeleteNumbersBatchResponse>(req, cancellationToken);

--- a/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/CountryCoverageOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/CountryCoverageOperations.cs
@@ -1,25 +1,24 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.CountryCoverage;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
 {
-    public class CountryCoverageOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class CountryCoverageOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), ICountryCoverageOperations
     {
         /// <inheritdoc />
         public async Task<ListCountryCoverageResponse> List(CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"country_coverage");
+            var req = new TelnyxRequest($"country_coverage");
             return await ExecuteAsync<ListCountryCoverageResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<GetCountryCoverageResponse> Get(string countryCode, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"country_coverage/countries/{countryCode}");
+            var req = new TelnyxRequest($"country_coverage/countries/{countryCode}");
             return await ExecuteAsync<GetCountryCoverageResponse>(req, cancellationToken);
         }
     }

--- a/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/CsvDownloadsOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/CsvDownloadsOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.CsvDownloads;
@@ -8,13 +7,13 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.CsvDownloads;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
 {
-    public class CsvDownloadsOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class CsvDownloadsOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), ICsvDownloadsOperations
     {
         /// <inheritdoc />
         public async Task<ListCsvDownloadsResponse> List(ListCsvDownloadsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("phone_numbers/csv_downloads")
+            var req = new TelnyxRequest("phone_numbers/csv_downloads")
                                 .AddPagination(request.PageSize);
 
             return await ExecuteAsync<ListCsvDownloadsResponse>(req, cancellationToken);
@@ -23,14 +22,14 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<CreateCsvDownloadResponse> Create(CancellationToken cancellationToken = default)
         {
-            var restRequest = new RestRequest("phone_numbers/csv_downloads", Method.Post);
+            var restRequest = new TelnyxRequest("phone_numbers/csv_downloads", TelnyxMethod.Post);
             return await ExecuteAsync<CreateCsvDownloadResponse>(restRequest, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<GetCsvDownloadResponse> Get(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/csv_downloads/{id}");
+            var req = new TelnyxRequest($"phone_numbers/csv_downloads/{id}");
             return await ExecuteAsync<GetCsvDownloadResponse>(req, cancellationToken);
         }
     }

--- a/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/InventoryLevelOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/InventoryLevelOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.InventoryLevel;
@@ -7,13 +6,13 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.InventoryLevel;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
 {
-    public class InventoryLevelOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class InventoryLevelOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IInventoryLevelOperations
     {
         /// <inheritdoc />
         public async Task<InventoryCoverageResponse> Get(InventoryCoverageRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("inventory_coverage")
+            var req = new TelnyxRequest("inventory_coverage")
                 .AddFilter("filter[npa]", request.Npa)
                 .AddFilter("filter[nxx]", request.Nxx)
                 .AddFilter("filter[administrative_area]", request.AdministrativeArea)

--- a/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/NumbersFeaturesOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/NumbersFeaturesOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
@@ -8,13 +7,13 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.NumbersFeatures;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
 {
-    public class NumbersFeaturesOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class NumbersFeaturesOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), INumbersFeaturesOperations
     {
         /// <inheritdoc />
         public async Task<GetNumbersFeaturesResponse> Get(GetNumbersFeaturesRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("numbers_features", Method.Post);
+            var req = new TelnyxRequest("numbers_features", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<GetNumbersFeaturesResponse>(req, cancellationToken);
         }

--- a/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/PhoneNumberBlockOrdersOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/PhoneNumberBlockOrdersOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
@@ -8,14 +7,14 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.PhoneNumberBlockOrders;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
 {
-    public class PhoneNumberBlockOrdersOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class PhoneNumberBlockOrdersOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IPhoneNumberBlockOrdersOperations
     {
         /// <inheritdoc />
         public async Task<ListNumberBlockOrdersResponse> List(ListNumberBlockOrdersRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("number_block_orders")
+            var req = new TelnyxRequest("number_block_orders")
                 .AddFilter("filter[status]", request.Status)
                 .AddFilter("filter[created_at][gt]", request.CreatedAfter)
                 .AddFilter("filter[created_at][lt]", request.CreatedBefore)
@@ -28,7 +27,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<CreateNumberBlockOrderResponse> Create(CreateNumberBlockOrderRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("number_block_orders", Method.Post);
+            var req = new TelnyxRequest("number_block_orders", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CreateNumberBlockOrderResponse>(req, cancellationToken);
         }
@@ -36,7 +35,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<GetNumberBlockOrderResponse> Get(string numberBlockOrderId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"number_block_orders/{numberBlockOrderId}");
+            var req = new TelnyxRequest($"number_block_orders/{numberBlockOrderId}");
 
             return await ExecuteAsync<GetNumberBlockOrderResponse>(req, cancellationToken);
         }

--- a/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/PhoneNumberBlocksBackgroundJobsOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/PhoneNumberBlocksBackgroundJobsOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
@@ -8,13 +7,13 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.PhoneNumberBlocksBackgro
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
 {
-    public class PhoneNumberBlocksBackgroundJobsOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class PhoneNumberBlocksBackgroundJobsOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IPhoneNumberBlocksBackgroundJobsOperations
     {
         /// <inheritdoc />
         public async Task<ListPhoneNumberBlockJobsResponse> List(ListPhoneNumberBlockJobsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("phone_number_blocks/jobs")
+            var req = new TelnyxRequest("phone_number_blocks/jobs")
                 .AddFilter("filter[type]", request.Type)
                 .AddFilter("filter[status]", request.Status)
                 .AddPagination(request.PageSize)
@@ -26,14 +25,14 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<GetPhoneNumberBlocksJobResponse> Get(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_number_blocks/jobs/{id}");
+            var req = new TelnyxRequest($"phone_number_blocks/jobs/{id}");
             return await ExecuteAsync<GetPhoneNumberBlocksJobResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<DeletePhoneNumberBlockResponse> Delete(DeletePhoneNumberBlockRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("phone_number_blocks/jobs/delete_phone_number_block", Method.Post);
+            var req = new TelnyxRequest("phone_number_blocks/jobs/delete_phone_number_block", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<DeletePhoneNumberBlockResponse>(req, cancellationToken);
         }

--- a/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/PhoneNumberConfigurationOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/PhoneNumberConfigurationOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
@@ -8,13 +7,13 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.PhoneNumberConfiguration
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
 {
-    public class PhoneNumberConfigurationOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class PhoneNumberConfigurationOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IPhoneNumberConfigurationOperations
     {
         /// <inheritdoc />
         public async Task<ListNumbersResponse> List(ListNumbersRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("phone_numbers")
+            var req = new TelnyxRequest("phone_numbers")
                 .AddFilterList("filter[tag]", request.Tags)
                 .AddFilter("filter[phone_number]", request.PhoneNumber)
                 .AddFilter("filter[status]", request.Status)
@@ -37,7 +36,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<SlimListNumbersResponse> SlimList(SlimListNumbersRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("phone_numbers/slim")
+            var req = new TelnyxRequest("phone_numbers/slim")
                 .AddPagination(request.PageSize)
                 .AddFilter("include_connection", request.IncludeConnection)
                 .AddFilter("include_tags", request.IncludeTags)
@@ -62,7 +61,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<GetNumberResponse> Get(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/{id}");
+            var req = new TelnyxRequest($"phone_numbers/{id}");
             return await ExecuteAsync<GetNumberResponse>(req, cancellationToken);
         }
 
@@ -71,7 +70,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
            ListNumbersWithVoiceSettingsRequest request,
            CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("phone_numbers/voice")
+            var req = new TelnyxRequest("phone_numbers/voice")
                             .AddPagination(request.PageSize)
                             .AddFilter("filter[phone_number]", request.PhoneNumber)
                             .AddFilter("filter[connection_name][contains]", request.ConnectionNameContains)
@@ -85,7 +84,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<GetNumberVoiceSettingsResponse> GetNumberVoiceSettings(string phoneNumberId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/{phoneNumberId}/voice");
+            var req = new TelnyxRequest($"phone_numbers/{phoneNumberId}/voice");
             return await ExecuteAsync<GetNumberVoiceSettingsResponse>(req, cancellationToken);
         }
 
@@ -93,7 +92,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         public async Task<UpdateNumberVoiceSettingsResponse> UpdateNumberVoiceSettings(string phoneNumberId,
             UpdateNumberVoiceSettingsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/{phoneNumberId}/voice", Method.Patch);
+            var req = new TelnyxRequest($"phone_numbers/{phoneNumberId}/voice", TelnyxMethod.Patch);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<UpdateNumberVoiceSettingsResponse>(req, cancellationToken);
@@ -102,7 +101,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<EnableEmergencyResponse> EnableEmergency(string phoneNumberId, EnableEmergencyRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/{phoneNumberId}/actions/enable_emergency", Method.Post);
+            var req = new TelnyxRequest($"phone_numbers/{phoneNumberId}/actions/enable_emergency", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<EnableEmergencyResponse>(req, cancellationToken);
@@ -111,7 +110,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<ChangeBundleStatusResponse> ChangeBundleStatus(long phoneNumberId, ChangeBundleStatusRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/{phoneNumberId}/actions/bundle_status_change", Method.Patch);
+            var req = new TelnyxRequest($"phone_numbers/{phoneNumberId}/actions/bundle_status_change", TelnyxMethod.Patch);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<ChangeBundleStatusResponse>(req, cancellationToken);
@@ -122,7 +121,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         public async Task<UpdateNumberConfigurationResponse> Update(string phoneNumberId,
             UpdateNumberConfigurationRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/{phoneNumberId}", Method.Patch);
+            var req = new TelnyxRequest($"phone_numbers/{phoneNumberId}", TelnyxMethod.Patch);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<UpdateNumberConfigurationResponse>(req, cancellationToken);
@@ -132,7 +131,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         public async Task<DeletePhoneNumberResponse> Delete(string numberOrObjectId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/{numberOrObjectId}", Method.Delete);
+            var req = new TelnyxRequest($"phone_numbers/{numberOrObjectId}", TelnyxMethod.Delete);
 
             return await ExecuteAsync<DeletePhoneNumberResponse>(req, cancellationToken);
         }

--- a/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/PhoneNumberOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/PhoneNumberOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
 
@@ -8,7 +7,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
     /// <summary>
     /// Provides operations related to managing toll-free numbers, including toll-free verification.
     /// </summary>
-    public class PhoneNumberOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class PhoneNumberOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IPhoneNumberOperations
     {
         private readonly Lazy<IPhoneNumberSearchOperations> _phoneNumberSearchOperations = new(() =>

--- a/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/PhoneNumberOrdersOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/PhoneNumberOrdersOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
@@ -8,13 +7,13 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.PhoneNumberOrders;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
 {
-    public class PhoneNumberOrdersOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class PhoneNumberOrdersOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IPhoneNumberOrdersOperations
     {
         /// <inheritdoc />
         public async Task<ListNumberOrdersResponse> List(ListNumberOrdersRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("number_orders")
+            var req = new TelnyxRequest("number_orders")
                 .AddFilter("filter[status]", request.Status)
                 .AddFilter("filter[created_at][gt]", request.CreatedAfter)
                 .AddFilter("filter[created_at][lt]", request.CreatedBefore)
@@ -31,7 +30,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         public async Task<CreateNumberOrderResponse> Create(CreateNumberOrderRequest request,
         CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("number_orders", Method.Post);
+            var req = new TelnyxRequest("number_orders", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CreateNumberOrderResponse>(req, cancellationToken);
         }
@@ -40,14 +39,14 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         public async Task<GetNumberOrderResponse> Get(string numberOrderId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"number_orders/{numberOrderId}");
+            var req = new TelnyxRequest($"number_orders/{numberOrderId}");
             return await ExecuteAsync<GetNumberOrderResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<UpdateNumberOrderResponse> Update(string numberOrderId, UpdateNumberOrderRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"number_orders/{numberOrderId}", Method.Patch);
+            var req = new TelnyxRequest($"number_orders/{numberOrderId}", TelnyxMethod.Patch);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<UpdateNumberOrderResponse>(req, cancellationToken);
@@ -56,7 +55,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<ListSubNumberOrdersResponse> ListSubNumber(ListSubNumberOrdersRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("sub_number_orders")
+            var req = new TelnyxRequest("sub_number_orders")
                 .AddFilter("filter[status]", request.Status)
                 .AddFilter("filter[order_request_id]", request.OrderRequestId)
                 .AddFilter("filter[country_code]", request.CountryCode)
@@ -69,7 +68,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<GetSubNumberOrderResponse> GetSubNumber(string subNumberOrderId, GetSubNumberOrderRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"sub_number_orders/{subNumberOrderId}")
+            var req = new TelnyxRequest($"sub_number_orders/{subNumberOrderId}")
                 .AddFilter("filter[include_phone_numbers]", request.IncludePhoneNumbers);
 
             return await ExecuteAsync<GetSubNumberOrderResponse>(req, cancellationToken);
@@ -78,7 +77,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<UpdateSubNumberOrderResponse> UpdateSubNumber(string subNumberOrderId, UpdateSubNumberOrderRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"sub_number_orders/{subNumberOrderId}", Method.Patch);
+            var req = new TelnyxRequest($"sub_number_orders/{subNumberOrderId}", TelnyxMethod.Patch);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<UpdateSubNumberOrderResponse>(req, cancellationToken);
@@ -87,14 +86,14 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<CancelNumberOrderResponse> CancelSubNumber(string subNumberOrderId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"sub_number_orders/{subNumberOrderId}/cancel", Method.Patch);
+            var req = new TelnyxRequest($"sub_number_orders/{subNumberOrderId}/cancel", TelnyxMethod.Patch);
             return await ExecuteAsync<CancelNumberOrderResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<ListNumberOrderPhonesResponse> ListNumberAssociatedOrders(ListNumberOrderPhonesRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("number_order_phone_numbers")
+            var req = new TelnyxRequest("number_order_phone_numbers")
                 .AddFilter("filter[country_code]", request.CountryCode);
 
             return await ExecuteAsync<ListNumberOrderPhonesResponse>(req, cancellationToken);
@@ -103,14 +102,14 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<SingleNumberOrderPhoneResponse> GetNumberAssociatedOrders(string numberOrderPhoneNumberId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"number_order_phone_numbers/{numberOrderPhoneNumberId}");
+            var req = new TelnyxRequest($"number_order_phone_numbers/{numberOrderPhoneNumberId}");
             return await ExecuteAsync<SingleNumberOrderPhoneResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<UpdateNumberOrderPhoneResponse> UpdateNumberAssociatedOrders(string numberOrderPhoneNumberId, UpdateNumberOrderPhoneRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"number_order_phone_numbers/{numberOrderPhoneNumberId}", Method.Patch);
+            var req = new TelnyxRequest($"number_order_phone_numbers/{numberOrderPhoneNumberId}", TelnyxMethod.Patch);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<UpdateNumberOrderPhoneResponse>(req, cancellationToken);
         }
@@ -118,7 +117,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<CreateCommentResponse> CreateComment(CreateCommentRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("comments", Method.Post);
+            var req = new TelnyxRequest("comments", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CreateCommentResponse>(req, cancellationToken);
         }
@@ -126,7 +125,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<ListCommentsResponse> ListComment(ListCommentsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("comments")
+            var req = new TelnyxRequest("comments")
                 .AddFilter("filter[comment_record_type]", request.CommentRecordType)
                 .AddFilter("filter[comment_record_id]", request.CommentRecordId);
 
@@ -136,14 +135,14 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<GetCommentResponse> GetComment(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"comments/{id}");
+            var req = new TelnyxRequest($"comments/{id}");
             return await ExecuteAsync<GetCommentResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<MarkCommentReadResponse> MarkCommentAsRead(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"comments/{id}/read", Method.Patch);
+            var req = new TelnyxRequest($"comments/{id}/read", TelnyxMethod.Patch);
             return await ExecuteAsync<MarkCommentReadResponse>(req, cancellationToken);
         }
     }

--- a/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/PhoneNumberReservationsOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/PhoneNumberReservationsOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
@@ -8,13 +7,13 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.PhoneNumberReservartions
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
 {
-    public class PhoneNumberReservationsOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class PhoneNumberReservationsOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IPhoneNumberReservationsOperations
     {
         /// <inheritdoc />
         public async Task<ListNumberReservationsResponse> List(ListNumberReservationsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("number_reservations")
+            var req = new TelnyxRequest("number_reservations")
                 .AddFilter("filter[status]", request.Status)
                 .AddFilter("filter[created_at][gt]", request.CreatedAfter)
                 .AddFilter("filter[created_at][lt]", request.CreatedBefore)
@@ -29,7 +28,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         public async Task<CreateNumberReservationResponse> Create(
             CreateNumberReservationRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"number_reservations", Method.Post);
+            var req = new TelnyxRequest($"number_reservations", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CreateNumberReservationResponse>(req, cancellationToken);
         }
@@ -37,14 +36,14 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<GetNumberReservationResponse> Get(string numberReservationId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"number_reservations/{numberReservationId}");
+            var req = new TelnyxRequest($"number_reservations/{numberReservationId}");
             return await ExecuteAsync<GetNumberReservationResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<ExtendNumberReservationResponse> Extend(string numberReservationId, CancellationToken cancellationToken = default)
         {
-            var request = new RestRequest($"number_reservations/{numberReservationId}/actions/extend", Method.Post);
+            var request = new TelnyxRequest($"number_reservations/{numberReservationId}/actions/extend", TelnyxMethod.Post);
 
             return await ExecuteAsync<ExtendNumberReservationResponse>(request, cancellationToken);
         }

--- a/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/PhoneNumberSearchOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/PhoneNumberSearchOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.PhoneNumberSearch;
@@ -7,14 +6,14 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.PhoneNumberSearch;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
 {
-    public class PhoneNumberSearchOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class PhoneNumberSearchOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IPhoneNumberSearchOperations
     {
         /// <inheritdoc />
         public async Task<AvailablePhoneNumbersResponse> AvailableNumbers(AvailablePhoneNumbersRequest request,
     CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("available_phone_numbers")
+            var req = new TelnyxRequest("available_phone_numbers")
                 .AddFilter("filter[administrative_area]", request.AdministrativeArea)
                 .AddFilter("filter[phone_number][contains]", request.Contains)
                 .AddFilter("filter[country_code]", request.CountryCode)
@@ -37,7 +36,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<ListAvailablePhoneNumberBlocksResponse> ListAvailableNumberBlocks(ListAvailablePhoneNumberBlocksRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("available_phone_number_blocks")
+            var req = new TelnyxRequest("available_phone_number_blocks")
                 .AddFilter("filter[locality]", request.Locality)
                 .AddFilter("filter[country_code]", request.CountryCode)
                 .AddFilter("filter[national_destination_code]", request.NationalDestinationCode)

--- a/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/RegulatoryRequirementsOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/RegulatoryRequirementsOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
 using TelnyxSharp.Numbers.Models.PhoneNumbers.Requests.RegulatoryRequirements;
@@ -7,13 +6,13 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.RegulatoryRequirements;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
 {
-    public class RegulatoryRequirementsOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class RegulatoryRequirementsOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IRegulatoryRequirementsOperations
     {
         /// <inheritdoc />
         public async Task<GetRegulatoryRequirementsResponse> Get(GetRegulatoryRequirementsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("regulatory_requirements")
+            var req = new TelnyxRequest("regulatory_requirements")
                 .AddFilter("filter[phone_number]", request.PhoneNumber)
                 .AddFilter("filter[requirement_group_id]", request.RequirementGroupId)
                 .AddFilter("filter[country_code]", request.CountryCode)
@@ -26,7 +25,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<ListRegulatoryRequirementsResponse> GetPhoneNumber(ListRegulatoryRequirementsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("phone_numbers_regulatory_requirements")
+            var req = new TelnyxRequest("phone_numbers_regulatory_requirements")
                         .AddFilter("filter[phone_number]", request.PhoneNumber);
 
             return await ExecuteAsync<ListRegulatoryRequirementsResponse>(req, cancellationToken);

--- a/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/RequirementGroupsOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PhoneNumbers/RequirementGroupsOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
@@ -8,14 +7,14 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.RequirementGroups;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
 {
-    public class RequirementGroupsOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class RequirementGroupsOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IRequirementGroupsOperations
     {
         /// <inheritdoc />
         public async Task<UpdateSubNumberOrderRequirementResponse> UpdateSubNumber(string subNumberOrderId, UpdateSubNumberOrderRequirementRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"sub_number_orders/{subNumberOrderId}/requirement_group", Method.Post);
+            var req = new TelnyxRequest($"sub_number_orders/{subNumberOrderId}/requirement_group", TelnyxMethod.Post);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<UpdateSubNumberOrderRequirementResponse>(req, cancellationToken);
@@ -25,7 +24,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         public async Task<UpdatePhoneNumberOrderRequirementResponse> UpdatePhoneNumber(string phoneNumberOrderId, UpdatePhoneNumberOrderRequirementRequest request,
            CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"number_order_phone_numbers/{phoneNumberOrderId}/requirement_group", Method.Post);
+            var req = new TelnyxRequest($"number_order_phone_numbers/{phoneNumberOrderId}/requirement_group", TelnyxMethod.Post);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<UpdatePhoneNumberOrderRequirementResponse>(req, cancellationToken);
@@ -34,7 +33,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<ListRequirementGroupsResponse> List(ListRequirementGroupsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("requirement_groups")
+            var req = new TelnyxRequest("requirement_groups")
                 .AddFilter("filter[country_code]", request.CountryCode)
                 .AddFilter("filter[phone_number_type]", request.PhoneNumberType)
                 .AddFilter("filter[action]", request.Action)
@@ -47,7 +46,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<CreateRequirementGroupResponse> Create(CreateRequirementGroupRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("requirement_groups", Method.Post);
+            var req = new TelnyxRequest("requirement_groups", TelnyxMethod.Post);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CreateRequirementGroupResponse>(req, cancellationToken);
@@ -56,21 +55,21 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         /// <inheritdoc />
         public async Task<GetRequirementGroupResponse> Get(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"requirement_groups/{id}");
+            var req = new TelnyxRequest($"requirement_groups/{id}");
             return await ExecuteAsync<GetRequirementGroupResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<DeleteRequirementGroupResponse> Delete(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"requirement_groups/{id}", Method.Delete);
+            var req = new TelnyxRequest($"requirement_groups/{id}", TelnyxMethod.Delete);
             return await ExecuteAsync<DeleteRequirementGroupResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<UpdateRequirementGroupResponse> Update(string id, UpdateRequirementGroupRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"requirement_groups/{id}", Method.Patch);
+            var req = new TelnyxRequest($"requirement_groups/{id}", TelnyxMethod.Patch);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<UpdateRequirementGroupResponse>(req, cancellationToken);
@@ -80,7 +79,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PhoneNumbers
         public async Task<SubmitRequirementGroupApprovalResponse> SubmitForApproval(string id,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"requirement_groups/{id}/submit_for_approval", Method.Post);
+            var req = new TelnyxRequest($"requirement_groups/{id}/submit_for_approval", TelnyxMethod.Post);
             return await ExecuteAsync<SubmitRequirementGroupApprovalResponse>(req, cancellationToken);
         }
     }

--- a/TelnyxSharp/Numbers/Operations/Numbers/PortingOrder/PortingOrderOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/PortingOrder/PortingOrderOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
@@ -8,13 +7,13 @@ using TelnyxSharp.Numbers.Models.PhoneNumbers.Responses.PortingOrder;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
 {
-    public class PortingOrderOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class PortingOrderOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IPortingOrderOperations
     {
         /// <inheritdoc />
         public async Task<CreatePortingOrderResponse> Create(CreatePortingOrderRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("porting_orders", Method.Post);
+            var req = new TelnyxRequest("porting_orders", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CreatePortingOrderResponse>(req, cancellationToken);
@@ -24,7 +23,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         public async Task<ListPortingOrdersResponse> List(ListPortingOrdersRequest request,
          CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("porting_orders")
+            var req = new TelnyxRequest("porting_orders")
                             .AddFilter("filter[status]", request.Status)
                             .AddFilter("include_phone_numbers", request.IncludePhoneNumbers)
                             .AddFilter("filter[customer_reference]", request.CustomerReference)
@@ -47,7 +46,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<RetrievePortingOrderResponse> Get(string id, RetrievePortingOrderRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{id}")
+            var req = new TelnyxRequest($"porting_orders/{id}")
                 .AddFilter("include_phone_numbers", request.IncludePhoneNumbers);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
@@ -57,7 +56,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<EditPortingOrderResponse> Edit(string id, EditPortingOrderRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{id}", Method.Patch);
+            var req = new TelnyxRequest($"porting_orders/{id}", TelnyxMethod.Patch);
 
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<EditPortingOrderResponse>(req, cancellationToken);
@@ -66,7 +65,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<DeletePortingOrderResponse> Delete(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{id}", Method.Delete);
+            var req = new TelnyxRequest($"porting_orders/{id}", TelnyxMethod.Delete);
 
             return await ExecuteAsync<DeletePortingOrderResponse>(req, cancellationToken);
         }
@@ -74,7 +73,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<DownloadLoaTemplateResponse> DownloadTemplate(string PortingOrderId, DownloadLoaTemplateRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{PortingOrderId}/loa_template")
+            var req = new TelnyxRequest($"porting_orders/{PortingOrderId}/loa_template")
                 .AddFilter("loa_configuration_id", request.LoaConfigurationId);
 
             return await ExecuteAsync<DownloadLoaTemplateResponse>(req, cancellationToken);
@@ -83,21 +82,21 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<GetSubRequestResponse> GetSubRequest(string portingOrderId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{portingOrderId}/sub_request");
+            var req = new TelnyxRequest($"porting_orders/{portingOrderId}/sub_request");
             return await ExecuteAsync<GetSubRequestResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<CancelPortingOrderResponse> Cancel(string portingOrderId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{portingOrderId}/actions/cancel", Method.Post);
+            var req = new TelnyxRequest($"porting_orders/{portingOrderId}/actions/cancel", TelnyxMethod.Post);
             return await ExecuteAsync<CancelPortingOrderResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<ConfirmPortingOrderResponse> Confirm(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{id}/actions/confirm", Method.Post);
+            var req = new TelnyxRequest($"porting_orders/{id}/actions/confirm", TelnyxMethod.Post);
             return await ExecuteAsync<ConfirmPortingOrderResponse>(req, cancellationToken);
         }
 
@@ -105,7 +104,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         public async Task<SharePortingOrderResponse> Share(string id, SharePortingOrderRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{id}/actions/share", Method.Post);
+            var req = new TelnyxRequest($"porting_orders/{id}/actions/share", TelnyxMethod.Post);
             req.AddJsonBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<SharePortingOrderResponse>(req, cancellationToken);
         }
@@ -113,14 +112,14 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<ActivatePortingOrderResponse> Activate(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{id}/actions/activate", Method.Post);
+            var req = new TelnyxRequest($"porting_orders/{id}/actions/activate", TelnyxMethod.Post);
             return await ExecuteAsync<ActivatePortingOrderResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<ListPortingActivationJobsResponse> ListActivationJobs(string id, ListPortingActivationJobsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{id}/activation_jobs")
+            var req = new TelnyxRequest($"porting_orders/{id}/activation_jobs")
                 .AddPagination(request?.PageSize);
 
             return await ExecuteAsync<ListPortingActivationJobsResponse>(req, cancellationToken);
@@ -129,7 +128,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<GetPortingActivationJobsResponse> GetActivationJobs(string id, string activationJobId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{id}/activation_jobs/{activationJobId}");
+            var req = new TelnyxRequest($"porting_orders/{id}/activation_jobs/{activationJobId}");
 
             return await ExecuteAsync<GetPortingActivationJobsResponse>(req, cancellationToken);
         }
@@ -138,7 +137,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         public async Task<UpdatePortingActivationJobResponse> UpdateActivationJob(string id, string activationJobId, UpdatePortingActivationJobRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{id}/activation_jobs/{activationJobId}", Method.Patch);
+            var req = new TelnyxRequest($"porting_orders/{id}/activation_jobs/{activationJobId}", TelnyxMethod.Patch);
             req.AddJsonBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<UpdatePortingActivationJobResponse>(req, cancellationToken);
         }
@@ -146,7 +145,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<CreatePortingCommentResponse> CreateComment(string portingOrderId, CreatePortingCommentRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{portingOrderId}/comments", Method.Post);
+            var req = new TelnyxRequest($"porting_orders/{portingOrderId}/comments", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CreatePortingCommentResponse>(req, cancellationToken);
         }
@@ -155,7 +154,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         public async Task<ListPortingCommentsResponse> ListComment(string portingOrderId, ListPortingCommentsRequest request,
                    CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{portingOrderId}/comments")
+            var req = new TelnyxRequest($"porting_orders/{portingOrderId}/comments")
                 .AddPagination(request.PageSize);
 
             return await ExecuteAsync<ListPortingCommentsResponse>(req, cancellationToken);
@@ -165,7 +164,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         public async Task<ListAllowedFocWindowsResponse> ListAllowedFocWindows(string portingOrderId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{portingOrderId}/allowed_foc_windows");
+            var req = new TelnyxRequest($"porting_orders/{portingOrderId}/allowed_foc_windows");
             return await ExecuteAsync<ListAllowedFocWindowsResponse>(req, cancellationToken);
         }
 
@@ -173,7 +172,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         public async Task<ListPortingOrderRequirementsResponse> ListRequirements(string portingOrderId, ListPortingOrderRequirementsRequest request,
         CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{portingOrderId}/requirements")
+            var req = new TelnyxRequest($"porting_orders/{portingOrderId}/requirements")
                             .AddPagination(request.PageSize);
 
             return await ExecuteAsync<ListPortingOrderRequirementsResponse>(req, cancellationToken);
@@ -182,7 +181,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<ListPortingExceptionTypesResponse> ListExceptionTypes(CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("porting_orders/exception_types");
+            var req = new TelnyxRequest("porting_orders/exception_types");
 
             return await ExecuteAsync<ListPortingExceptionTypesResponse>(req, cancellationToken);
         }
@@ -191,7 +190,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         public async Task<ListPhoneNumberConfigurationsResponse> ListPhoneNumberConfigurations(ListPhoneNumberConfigurationsRequest request,
            CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("porting_orders/phone_number_configurations")
+            var req = new TelnyxRequest("porting_orders/phone_number_configurations")
                 .AddPagination(request.PageSize)
                 .AddFilter("filter[porting_order_id]", request.PortingOrderId)
                 .AddFilter("filter[porting_order_id][in][]", request.PortingOrderIds)
@@ -209,7 +208,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<ListPortingPhoneNumbersResponse> ListPhoneNumbers(ListPortingPhoneNumbersRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_phone_numbers")
+            var req = new TelnyxRequest($"porting_phone_numbers")
                         .AddFilter("filter[porting_order_id]", request.PortingOrderId)
                         .AddFilterList("filter[porting_order_id][in][]", request.PortingOrderIds)
                         .AddFilter("filter[support_key][eq]", request.SupportKeyEq)
@@ -228,7 +227,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         public async Task<ListVerificationCodesResponse> ListVerificationCodes(string Id, ListVerificationCodesRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{Id}/verification_codes")
+            var req = new TelnyxRequest($"porting_orders/{Id}/verification_codes")
                 .AddFilter("filter[phone_number]", request.PhoneNumber)
                 .AddFilter("filter[phone_number][in][]", request.PhoneNumbers)
                 .AddFilter("filter[verified]", request.Verified)
@@ -242,7 +241,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         public async Task<VerifyCodesResponse> VerifyVerificationCodes(string id, VerifyCodesRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{id}/verification_codes/verify", Method.Post);
+            var req = new TelnyxRequest($"porting_orders/{id}/verification_codes/verify", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<VerifyCodesResponse>(req, cancellationToken);
         }
@@ -251,7 +250,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         public async Task<SendVerificationCodesResponse> SendVerificationCodes(string id, SendVerificationCodesRequest request,
            CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{id}/verification_codes/send", Method.Post);
+            var req = new TelnyxRequest($"porting_orders/{id}/verification_codes/send", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<SendVerificationCodesResponse>(req, cancellationToken);
         }
@@ -260,7 +259,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         public async Task<ListAdditionalDocumentsResponse> ListAdditionalDocuments(string id, ListAdditionalDocumentsRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{id}/additional_documents")
+            var req = new TelnyxRequest($"porting_orders/{id}/additional_documents")
                 .AddFilter("filter[document_type]", request.DocumentType)
                 .AddFilter("filter[document_type][in][]", request.DocumentTypes)
                 .AddPagination(request.PageSize)
@@ -272,7 +271,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<CreateAdditionalDocumentsResponse> CreateAdditionalDocuments(string id, CreateAdditionalDocumentsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{id}/additional_documents", Method.Post);
+            var req = new TelnyxRequest($"porting_orders/{id}/additional_documents", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CreateAdditionalDocumentsResponse>(req, cancellationToken);
         }
@@ -280,14 +279,14 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<DeleteAdditionalDocumentsResponse> DeleteAdditionalDocument(string portingOrderId, string additionalDocumentId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{portingOrderId}/additional_documents/{additionalDocumentId}", Method.Delete);
+            var req = new TelnyxRequest($"porting_orders/{portingOrderId}/additional_documents/{additionalDocumentId}", TelnyxMethod.Delete);
             return await ExecuteAsync<DeleteAdditionalDocumentsResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<ListPhoneNumberExtensionsResponse> ListPhoneNumberExtensions(string portingOrderId, ListPhoneNumberExtensionsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{portingOrderId}/phone_number_extensions")
+            var req = new TelnyxRequest($"porting_orders/{portingOrderId}/phone_number_extensions")
                 .AddFilter("filter[phone_number]", request.PhoneNumber)
                 .AddFilter("filter[phone_number][in][]", request.PhoneNumbers)
                 .AddFilter("filter[porting_phone_number_id]", request.PortingPhoneNumberId)
@@ -301,7 +300,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<CreatePhoneNumberExtensionsResponse> CreatePhoneNumberExtensions(string portingOrderId, CreatePhoneNumberExtensionsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{portingOrderId}/phone_number_extensions", Method.Post);
+            var req = new TelnyxRequest($"porting_orders/{portingOrderId}/phone_number_extensions", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CreatePhoneNumberExtensionsResponse>(req, cancellationToken);
@@ -310,14 +309,14 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<DeletePhoneNumberExtensionsResponse> DeletePhoneNumberExtensionAsync(string portingOrderId, string extensionId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{portingOrderId}/phone_number_extensions/{extensionId}", Method.Delete);
+            var req = new TelnyxRequest($"porting_orders/{portingOrderId}/phone_number_extensions/{extensionId}", TelnyxMethod.Delete);
             return await ExecuteAsync<DeletePhoneNumberExtensionsResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<ListPortingPhoneBlocksResponse> ListPhoneNumberBlocks(string portingOrderId, ListPortingPhoneBlocksRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{portingOrderId}/phone_number_blocks")
+            var req = new TelnyxRequest($"porting_orders/{portingOrderId}/phone_number_blocks")
                 .AddFilter("filter[phone_number]", request.PhoneNumber)
                 .AddFilter("filter[phone_number][in][]", request.PhoneNumbers)
                 .AddFilter("sort[]", request.Sort)
@@ -329,7 +328,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<CreatePortingPhoneBlockResponse> CreatePhoneNumberBlocks(string portingOrderId, CreatePortingPhoneBlockRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{portingOrderId}/phone_number_blocks", Method.Post);
+            var req = new TelnyxRequest($"porting_orders/{portingOrderId}/phone_number_blocks", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CreatePortingPhoneBlockResponse>(req, cancellationToken);
@@ -338,7 +337,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<DeletePortingPhoneBlockResponse> DeletePhoneNumberBlocks(string portingOrderId, string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting_orders/{portingOrderId}/phone_number_blocks/{id}", Method.Delete);
+            var req = new TelnyxRequest($"porting_orders/{portingOrderId}/phone_number_blocks/{id}", TelnyxMethod.Delete);
             return await ExecuteAsync<DeletePortingPhoneBlockResponse>(req, cancellationToken);
         }
 
@@ -346,7 +345,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         public async Task<ListPortingReportsResponse> ListPortingReports(ListPortingReportsRequest request,
                 CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("porting/reports")
+            var req = new TelnyxRequest("porting/reports")
                 .AddPagination(request.PageSize)
                 .AddFilter("filter[report_type]", request.ReportType)
                 .AddFilter("filter[status]", request.Status);
@@ -357,7 +356,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<GetPortingReportResponse> GetPortingReports(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting/reports/{id}");
+            var req = new TelnyxRequest($"porting/reports/{id}");
             return await ExecuteAsync<GetPortingReportResponse>(req, cancellationToken);
         }
 
@@ -365,7 +364,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         public async Task<ListLoaConfigurationsResponse> ListPortingReports(ListLoaConfigurationsRequest request,
                 CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("porting/loa_configurations")
+            var req = new TelnyxRequest("porting/loa_configurations")
                             .AddPagination(request.PageSize);
 
             return await ExecuteAsync<ListLoaConfigurationsResponse>(req, cancellationToken);
@@ -374,7 +373,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<CreateLoaConfigurationResponse> CreatePortingReports(CreateLoaConfigurationRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("porting/loa_configurations", Method.Post);
+            var req = new TelnyxRequest("porting/loa_configurations", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CreateLoaConfigurationResponse>(req, cancellationToken);
@@ -383,7 +382,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<PreviewLoaConfigurationResponse> PreviewConfigurationParamters(PreviewLoaConfigurationParamRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("porting/loa_configuration/preview", Method.Post);
+            var req = new TelnyxRequest("porting/loa_configuration/preview", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<PreviewLoaConfigurationResponse>(req, cancellationToken);
@@ -392,14 +391,14 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<GetLoaConfigurationResponse> GetConfiguration(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting/loa_configurations/{id}");
+            var req = new TelnyxRequest($"porting/loa_configurations/{id}");
             return await ExecuteAsync<GetLoaConfigurationResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<UpdateLoaConfigurationResponse> UpdateConfiguration(string id, UpdateLoaConfigurationRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting/loa_configurations/{id}", Method.Patch);
+            var req = new TelnyxRequest($"porting/loa_configurations/{id}", TelnyxMethod.Patch);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<UpdateLoaConfigurationResponse>(req, cancellationToken);
@@ -408,7 +407,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<DeleteLoaConfigurationResponse> DeleteConfiguration(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting/loa_configurations/{id}", Method.Delete);
+            var req = new TelnyxRequest($"porting/loa_configurations/{id}", TelnyxMethod.Delete);
 
             return await ExecuteAsync<DeleteLoaConfigurationResponse>(req, cancellationToken);
         }
@@ -416,7 +415,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<PreviewLoaConfigurationResponse> PreviewLoaConfiguration(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting/loa_configurations/{id}/preview");
+            var req = new TelnyxRequest($"porting/loa_configurations/{id}/preview");
 
             return await ExecuteAsync<PreviewLoaConfigurationResponse>(req, cancellationToken);
         }
@@ -424,7 +423,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<ListPortingEventsResponse> ListPortingEvents(ListPortingEventsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("porting/events")
+            var req = new TelnyxRequest("porting/events")
                 .AddPagination(request?.PageSize)
                 .AddFilter("filter[type]", request?.EventType)
                 .AddFilter("filter[porting_order_id]", request?.PortingOrderId)
@@ -437,14 +436,14 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.PortingOrder
         /// <inheritdoc />
         public async Task<GetPortingEventResponse> GetPortingEvents(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting/events/{id}");
+            var req = new TelnyxRequest($"porting/events/{id}");
             return await ExecuteAsync<GetPortingEventResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<RepublishPortingEventsResponse> RepublishPortingEvents(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"porting/events/{id}/republish", Method.Post);
+            var req = new TelnyxRequest($"porting/events/{id}/republish", TelnyxMethod.Post);
             return await ExecuteAsync<RepublishPortingEventsResponse>(req, cancellationToken);
         }
     }

--- a/TelnyxSharp/Numbers/Operations/Numbers/Voicemail/VoicemailOperations.cs
+++ b/TelnyxSharp/Numbers/Operations/Numbers/Voicemail/VoicemailOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Numbers.Interfaces;
@@ -8,14 +7,14 @@ using TelnyxSharp.Numbers.Models.Voicemail.Responses;
 
 namespace TelnyxSharp.Numbers.Operations.Numbers.Voicemail
 {
-    public class VoicemailOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class VoicemailOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IVoicemailOperations
     {
         /// <inheritdoc />
         public async Task<GetVoicemailResponse> Get(string phoneNumberId,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/{phoneNumberId}/voicemail");
+            var req = new TelnyxRequest($"phone_numbers/{phoneNumberId}/voicemail");
             return await ExecuteAsync<GetVoicemailResponse>(req, cancellationToken);
         }
 
@@ -23,7 +22,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.Voicemail
         public async Task<CreateVoicemailResponse> Create(string phoneNumberId, CreateVoicemailRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/{phoneNumberId}/voicemail", Method.Post);
+            var req = new TelnyxRequest($"phone_numbers/{phoneNumberId}/voicemail", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CreateVoicemailResponse>(req, cancellationToken);
@@ -32,7 +31,7 @@ namespace TelnyxSharp.Numbers.Operations.Numbers.Voicemail
         /// <inheritdoc />
         public async Task<UpdateVoicemailResponse> Update(string phoneNumberId, UpdateVoicemailRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"phone_numbers/{phoneNumberId}/voicemail", Method.Patch);
+            var req = new TelnyxRequest($"phone_numbers/{phoneNumberId}/voicemail", TelnyxMethod.Patch);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<UpdateVoicemailResponse>(req, cancellationToken);

--- a/TelnyxSharp/RestRequestQueryBuilderExtensions.cs
+++ b/TelnyxSharp/RestRequestQueryBuilderExtensions.cs
@@ -1,10 +1,10 @@
-﻿using RestSharp;
 using System.Text.Json;
+using TelnyxSharp.Base;
 using TelnyxSharp.Enums;
 namespace TelnyxSharp
 {
     /// <summary>
-    /// Provides extension methods for RestRequest to add query parameters and filters.
+    /// Provides extension methods for TelnyxRequest to add query parameters and filters.
     /// </summary>
     public static class RestRequestQueryBuilderExtensions
     {
@@ -16,7 +16,7 @@ namespace TelnyxSharp
         /// Adds a filter with an enum value to the request query parameters.
         /// Uses JsonPropertyName attribute value if available.
         /// </summary>
-        public static RestRequest AddFilter(this RestRequest request, string key, object? value = null, FilterOperator? filterOperator = null)
+        public static TelnyxRequest AddFilter(this TelnyxRequest request, string key, object? value = null, FilterOperator? filterOperator = null)
         {
             if (value == null || (value is string strValue && string.IsNullOrWhiteSpace(strValue)))
             {
@@ -49,7 +49,7 @@ namespace TelnyxSharp
         /// Adds a list of values as query parameters with array notation.
         /// Filters out null, empty, or whitespace-only values.
         /// </summary>
-        public static RestRequest AddFilterList(this RestRequest request, string key, List<string>? values)
+        public static TelnyxRequest AddFilterList(this TelnyxRequest request, string key, List<string>? values)
         {
             if (values == null || values.Count == 0) return request;
             foreach (var value in values.Where(v => !string.IsNullOrWhiteSpace(v)))
@@ -63,7 +63,7 @@ namespace TelnyxSharp
         /// Page size is constrained between 1 and 250, defaulting to 50.
         /// Page number always starts at 1.
         /// </summary>
-        public static RestRequest AddPagination(this RestRequest request, int? pageSize)
+        public static TelnyxRequest AddPagination(this TelnyxRequest request, int? pageSize)
         {
             var size = Math.Min(MaxPageSize,
                       Math.Max(MinPageSize,

--- a/TelnyxSharp/TelnyxClient.cs
+++ b/TelnyxSharp/TelnyxClient.cs
@@ -1,8 +1,6 @@
 ﻿using Polly;
 using Polly.RateLimit;
-using RestSharp;
-using RestSharp.Authenticators;
-using RestSharp.Interceptors;
+using System.Net.Http.Headers;
 using TelnyxSharp.Base;
 using TelnyxSharp.DetailRecords.Interfaces;
 using TelnyxSharp.DetailRecords.Operations;
@@ -32,7 +30,8 @@ public class TelnyxClient : BaseOperations, ITelnyxClient
     private static readonly string DefaultLogPath = Path.Combine(Path.GetTempPath(), "TelnyxSDK", "logs");
     private readonly StreamWriter? _logWriter;
     private readonly FileStream? _logFileStream;
-    private readonly IRestClient? _v1Client;
+    private readonly HttpClient? _v1Client;
+    private readonly bool _debugMode;
 
     // Lazy-loaded API sections
     private readonly Lazy<ISmsMmsOperations> _smsmms;
@@ -70,22 +69,7 @@ public class TelnyxClient : BaseOperations, ITelnyxClient
 
     public TelnyxClient(string? apiKey = null, string? v1ApiUser = null, string? v1ApiToken = null, bool debugMode = false, string? debugLogPath = null)
     {
-        var v2Options = new RestClientOptions("https://api.telnyx.com/v2/")
-        {
-            Authenticator = !string.IsNullOrEmpty(apiKey) ? new JwtAuthenticator(apiKey) : null,
-            ThrowOnDeserializationError = false,
-            ThrowOnAnyError = false,
-        };
-
-        RestClientOptions v1Options = null;
-        if (!string.IsNullOrEmpty(v1ApiToken))
-        {
-            v1Options = new RestClientOptions("https://api.telnyx.com/")
-            {
-                ThrowOnDeserializationError = false,
-                ThrowOnAnyError = false,
-            };
-        }
+        _debugMode = debugMode;
 
         if (debugMode)
         {
@@ -99,17 +83,6 @@ public class TelnyxClient : BaseOperations, ITelnyxClient
 
             _logWriter.WriteLine($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] TelnyxSDK Debug Log File: {logFilePath}");
             _logWriter.WriteLine($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] Session Started: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
-
-            v2Options.Interceptors = new List<Interceptor> { new TelnyxAsyncLoggingInterceptor(_logWriter) };
-            v2Options.ThrowOnAnyError = debugMode;
-            v2Options.ThrowOnDeserializationError = debugMode;
-
-            if (v1Options != null)
-            {
-                v1Options.Interceptors = new List<Interceptor> { new TelnyxAsyncLoggingInterceptor(_logWriter) };
-                v1Options.ThrowOnAnyError = debugMode;
-                v1Options.ThrowOnDeserializationError = debugMode;
-            }
         }
 
         var rateLimitRetryPolicy = Policy
@@ -122,15 +95,27 @@ public class TelnyxClient : BaseOperations, ITelnyxClient
                     return ex?.RetryAfter ?? TimeSpan.FromSeconds(1);
                 },
                 onRetryAsync: (exception, timeSpan, attempt, context) => Task.CompletedTask);
-        // Initialize base with configured optionsQ
-        base.Client = new RestClient(v2Options);
+
+        // Build the v2 client (replaces RestSharp JwtAuthenticator with a Bearer default header).
+        var v2Client = new HttpClient(BuildHandlerPipeline())
+        {
+            BaseAddress = new Uri("https://api.telnyx.com/v2/")
+        };
+        if (!string.IsNullOrEmpty(apiKey))
+            v2Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        base.Client = v2Client;
         base.RateLimitRetryPolicy = rateLimitRetryPolicy;
 
-        if (v1Options != null)
+        // Build the v1 client only when a v1 token is supplied.
+        if (!string.IsNullOrEmpty(v1ApiToken))
         {
-            _v1Client = new RestClient(v1Options);
-            _v1Client.AddDefaultHeader("x-api-user", v1ApiUser);
-            _v1Client.AddDefaultHeader("x-api-token", v1ApiToken);
+            _v1Client = new HttpClient(BuildHandlerPipeline())
+            {
+                BaseAddress = new Uri("https://api.telnyx.com/")
+            };
+            _v1Client.DefaultRequestHeaders.TryAddWithoutValidation("x-api-user", v1ApiUser);
+            _v1Client.DefaultRequestHeaders.TryAddWithoutValidation("x-api-token", v1ApiToken);
         }
         else
         {
@@ -203,6 +188,24 @@ public class TelnyxClient : BaseOperations, ITelnyxClient
             }, LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
+    /// <summary>
+    /// Builds the <see cref="HttpClient"/> handler pipeline, inserting the debug logging
+    /// <see cref="DelegatingHandler"/> in front of the primary handler when debug mode is enabled.
+    /// Each client gets its own handler chain (a <see cref="DelegatingHandler"/> instance cannot be shared);
+    /// in debug mode the interceptors share the single log writer.
+    /// </summary>
+    private HttpMessageHandler BuildHandlerPipeline()
+    {
+        var primary = new SocketsHttpHandler();
+
+        if (_debugMode && _logWriter != null)
+        {
+            return new TelnyxAsyncLoggingInterceptor(_logWriter) { InnerHandler = primary };
+        }
+
+        return primary;
+    }
+
     public void Dispose()
     {
         // Dispose any initialized components
@@ -268,10 +271,12 @@ public class TelnyxClient : BaseOperations, ITelnyxClient
             disposableV1Operations.Dispose();
         }
 
-        _logWriter?.Dispose();
-        _logFileStream?.Dispose();
+        // Dispose the HttpClients first: this disposes their handler chains, including the
+        // logging interceptor, which performs its final flush to the still-open writer.
         Client?.Dispose();
         _v1Client?.Dispose();
+        _logWriter?.Dispose();
+        _logFileStream?.Dispose();
         GC.SuppressFinalize(this);
     }
 }

--- a/TelnyxSharp/TelnyxLoggingInterceptor.cs
+++ b/TelnyxSharp/TelnyxLoggingInterceptor.cs
@@ -1,15 +1,14 @@
-﻿using RestSharp.Interceptors;
 using System.Collections.Concurrent;
 using System.Text;
 
 namespace TelnyxSharp
 {
     /// <summary>
-    /// Interceptor for asynchronously logging Telnyx API requests and responses.
+    /// A <see cref="DelegatingHandler"/> for asynchronously logging Telnyx API requests and responses.
     /// Logs request and response details (headers, body, status) to a specified log writer.
     /// The logging is performed asynchronously in the background to avoid blocking API calls.
     /// </summary>
-    public class TelnyxAsyncLoggingInterceptor : Interceptor, IDisposable
+    public class TelnyxAsyncLoggingInterceptor : DelegatingHandler, IDisposable
     {
         private readonly StreamWriter _logWriter;
         private readonly ConcurrentQueue<string> _logQueue;
@@ -41,6 +40,18 @@ namespace TelnyxSharp
         }
 
         /// <summary>
+        /// Logs the outgoing request and incoming response around the inner handler.
+        /// </summary>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            await LogRequestAsync(request, cancellationToken);
+            var response = await base.SendAsync(request, cancellationToken);
+            await LogResponseAsync(response, cancellationToken);
+            return response;
+        }
+
+        /// <summary>
         /// Processes and flushes queued log entries asynchronously.
         /// Logs are written to the <see cref="StreamWriter"/> at regular intervals.
         /// </summary>
@@ -65,7 +76,7 @@ namespace TelnyxSharp
                 }
                 catch (Exception ex)
                 {
-                    // Log processing error - in a production environment, 
+                    // Log processing error - in a production environment,
                     // you might want to emit this to a different error log
                     try
                     {
@@ -106,13 +117,9 @@ namespace TelnyxSharp
         }
 
         /// <summary>
-        /// Called before an HTTP request is sent. Logs the request details.
+        /// Logs the request details before it is sent.
         /// </summary>
-        /// <param name="requestMessage">The <see cref="HttpRequestMessage"/> to be sent.</param>
-        /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        public override async ValueTask BeforeHttpRequest(HttpRequestMessage requestMessage,
-            CancellationToken cancellationToken)
+        private async Task LogRequestAsync(HttpRequestMessage requestMessage, CancellationToken cancellationToken)
         {
             if (_disposed) return;
 
@@ -164,13 +171,9 @@ namespace TelnyxSharp
         }
 
         /// <summary>
-        /// Called after an HTTP request has completed. Logs the response details.
+        /// Logs the response details after it has been received.
         /// </summary>
-        /// <param name="responseMessage">The <see cref="HttpResponseMessage"/> received.</param>
-        /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        public override async ValueTask AfterHttpRequest(HttpResponseMessage responseMessage,
-            CancellationToken cancellationToken)
+        private async Task LogResponseAsync(HttpResponseMessage responseMessage, CancellationToken cancellationToken)
         {
             if (_disposed) return;
 
@@ -222,55 +225,64 @@ namespace TelnyxSharp
         /// <summary>
         /// Disposes of the interceptor, ensuring that the background task and resources are properly cleaned up.
         /// </summary>
-        public void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            if (_disposed) return;
+            if (_disposed)
+            {
+                base.Dispose(disposing);
+                return;
+            }
 
             _disposed = true;
 
-            try
+            if (disposing)
             {
-                // Signal the processing task to stop
-                _cancellationSource.Cancel();
-
-                // Wait for the processing task to complete (with timeout)
-                if (!_processTask.Wait(TimeSpan.FromSeconds(5)))
-                {
-                    // If task didn't complete in time, force a final flush
-                    while (_logQueue.TryDequeue(out var message))
-                    {
-                        _logWriter.WriteLine(message);
-                    }
-                    _logWriter.Flush();
-                }
-            }
-            catch
-            {
-                // If async wait failed, attempt one final synchronous flush
                 try
                 {
-                    while (_logQueue.TryDequeue(out var message))
+                    // Signal the processing task to stop
+                    _cancellationSource.Cancel();
+
+                    // Wait for the processing task to complete (with timeout)
+                    if (!_processTask.Wait(TimeSpan.FromSeconds(5)))
                     {
-                        _logWriter.WriteLine(message);
+                        // If task didn't complete in time, force a final flush
+                        while (_logQueue.TryDequeue(out var message))
+                        {
+                            _logWriter.WriteLine(message);
+                        }
+                        _logWriter.Flush();
                     }
-                    _logWriter.Flush();
                 }
                 catch
                 {
-                    // Ignore final flush errors
+                    // If async wait failed, attempt one final synchronous flush
+                    try
+                    {
+                        while (_logQueue.TryDequeue(out var message))
+                        {
+                            _logWriter.WriteLine(message);
+                        }
+                        _logWriter.Flush();
+                    }
+                    catch
+                    {
+                        // Ignore final flush errors
+                    }
+                }
+                finally
+                {
+                    _cancellationSource.Dispose();
+
+                    // Clear the tracking collections
+                    _processedRequests.Clear();
+                    _processedResponses.Clear();
+
+                    // Clear any remaining items in queue (should be empty at this point)
+                    while (_logQueue.TryDequeue(out _)) { }
                 }
             }
-            finally
-            {
-                _cancellationSource.Dispose();
 
-                // Clear the tracking collections
-                _processedRequests.Clear();
-                _processedResponses.Clear();
-
-                // Clear any remaining items in queue (should be empty at this point)
-                while (_logQueue.TryDequeue(out _)) { }
-            }
+            base.Dispose(disposing);
         }
     }
 }

--- a/TelnyxSharp/TelnyxSharp.csproj
+++ b/TelnyxSharp/TelnyxSharp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -8,8 +8,8 @@
 		<Authors>Spire Recovery Solutions</Authors>
 		<Company>Spire Recovery Solutions</Company>
 		<Product>TelnyxSharp</Product>
-		<Description>A comprehensive .NET 9 SDK for the Telnyx API, providing seamless integration with Telnyx telephony services including SMS/MMS messaging, voice calls, number management, WebRTC, and more. Built exclusively for .NET 9 with full async support and built-in rate limiting. Requires .NET 9.0 or later.</Description>
-		<PackageTags>telnyx api rest client dotnet dotnet9 net9 sms mms voice telephony webrtc messaging sdk</PackageTags>
+		<Description>A comprehensive .NET 10 SDK for the Telnyx API, providing seamless integration with Telnyx telephony services including SMS/MMS messaging, voice calls, number management, WebRTC, and more. Built exclusively for .NET 10 with full async support and built-in rate limiting. Requires .NET 10.0 or later.</Description>
+		<PackageTags>telnyx api rest client dotnet dotnet10 net10 sms mms voice telephony webrtc messaging sdk</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageProjectUrl>https://github.com/Spire-Recovery-Solutions/TelnyxSharp</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/Spire-Recovery-Solutions/TelnyxSharp.git</RepositoryUrl>
@@ -21,9 +21,9 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.17" />
 		<PackageReference Include="Polly" Version="8.6.3" />
-		<PackageReference Include="RestSharp" Version="112.1.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/TelnyxSharp/V1Operations/Operations/CdrRequestsOperations.cs
+++ b/TelnyxSharp/V1Operations/Operations/CdrRequestsOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.V1Operations.Interfaces;
@@ -11,13 +10,13 @@ namespace TelnyxSharp.V1Operations.Operations
     /// <summary>
     /// Implements operations for CDR requests.
     /// </summary>
-    public class CdrRequestsOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class CdrRequestsOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
         : BaseOperations(client, rateLimitRetryPolicy), ICdrRequestsOperations
     {
         /// <inheritdoc />
         public async Task<CreateCdrRequestsResponse> Create(CreateCdrRequestsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("reporting/cdr_requests", Method.Post);
+            var req = new TelnyxRequest("reporting/cdr_requests", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CreateCdrRequestsResponse>(req, cancellationToken);
         }
@@ -25,7 +24,7 @@ namespace TelnyxSharp.V1Operations.Operations
         /// <inheritdoc />
         public async Task<ListCdrRequestsResponse> List(ListCdrRequestsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("reporting/cdr_requests", Method.Get)
+            var req = new TelnyxRequest("reporting/cdr_requests", TelnyxMethod.Get)
                 .AddPagination(request.PageSize);
             return await ExecuteAsync<ListCdrRequestsResponse>(req, cancellationToken);
         }
@@ -33,14 +32,14 @@ namespace TelnyxSharp.V1Operations.Operations
         /// <inheritdoc />
         public async Task<GetCdrRequestsResponse> Get(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"reporting/cdr_requests/{id}", Method.Get);
+            var req = new TelnyxRequest($"reporting/cdr_requests/{id}", TelnyxMethod.Get);
             return await ExecuteAsync<GetCdrRequestsResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<DeleteCdrRequestsResponse> Delete(string id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"reporting/cdr_requests/{id}", Method.Delete);
+            var req = new TelnyxRequest($"reporting/cdr_requests/{id}", TelnyxMethod.Delete);
             return await ExecuteAsync<DeleteCdrRequestsResponse>(req, cancellationToken);
         }
     }

--- a/TelnyxSharp/V1Operations/Operations/V1ApiOperations.cs
+++ b/TelnyxSharp/V1Operations/Operations/V1ApiOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.V1Operations.Interfaces;
 
@@ -9,7 +8,7 @@ namespace TelnyxSharp.V1Operations.Operations
     /// Provides operations for interacting with Telnyx v1 endpoints.
     /// Currently exposes only the CDR Request operations.
     /// </summary>
-    public class V1ApiOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy) : BaseOperations(client, rateLimitRetryPolicy), IV1ApiOperations
+    public class V1ApiOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy) : BaseOperations(client, rateLimitRetryPolicy), IV1ApiOperations
     {
         private readonly Lazy<ICdrRequestsOperations> _cdrRequests = new(() =>
             new CdrRequestsOperations(client, rateLimitRetryPolicy),

--- a/TelnyxSharp/Voice/Operations/ProgrammableVoice/CallCommandsOperations.cs
+++ b/TelnyxSharp/Voice/Operations/ProgrammableVoice/CallCommandsOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Voice.Interfaces;
@@ -8,13 +7,13 @@ using TelnyxSharp.Voice.Models.CallCommands.Responses;
 
 namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
 {
-    public class CallCommandsOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class CallCommandsOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), ICallCommandsOperations
     {
         /// <inheritdoc />
         public async Task<DialResponse> Dial(DialRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("calls", Method.Post);
+            var req = new TelnyxRequest("calls", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<DialResponse>(req, cancellationToken);
         }
@@ -23,7 +22,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         public async Task<CallCommandsResponse> AnswerCall(string callControlId, AnswerCallRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/answer", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/answer", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
         }
@@ -32,7 +31,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         public async Task<CallCommandsResponse?> BridgeCall(string callControlId, BridgeCallRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/bridge", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/bridge", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
         }
@@ -41,7 +40,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         public async Task<CallCommandsResponse?> EnqueueCall(string callControlId, EnqueueCallRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/enqueue", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/enqueue", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             var result = await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
             return result;
@@ -51,7 +50,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         public async Task<CallCommandsResponse?> StartForking(string callControlId, ForkMediaRequest request,
              CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/fork_start", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/fork_start", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
         }
@@ -60,7 +59,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         public async Task<CallCommandsResponse?> StopForking(string callControlId, ForkStopRequest request,
                 CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/fork_stop", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/fork_stop", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
         }
@@ -69,7 +68,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         public async Task<CallCommandsResponse?> Gather(string callControlId, GatherRequest request,
                  CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/gather", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/gather", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
         }
@@ -78,7 +77,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         public async Task<CallCommandsResponse?> GatherUsingAudio(string callControlId, GatherUsingAudioRequest request,
                 CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/gather_using_audio", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/gather_using_audio", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -88,7 +87,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         public async Task<CallCommandsResponse?> GatherUsingSpeak(string callControlId, GatherUsingSpeakRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/gather_using_speak", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/gather_using_speak", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
         }
@@ -99,7 +98,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             GatherUsingAiRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/gather_using_ai", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/gather_using_ai", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
         }
@@ -110,7 +109,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             GatherStopRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/gather_stop", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/gather_stop", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
         }
@@ -121,7 +120,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             AiAssistantStartRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/ai_assistant_start", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/ai_assistant_start", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
         }
@@ -132,7 +131,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             AiAssistantStartRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/ai_assistant_stop", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/ai_assistant_stop", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
         }
@@ -143,7 +142,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             UpdateClientStateRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/client_state_update", Method.Put);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/client_state_update", TelnyxMethod.Put);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
         }
@@ -154,7 +153,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             SipReferRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/refer", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/refer", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
         }
@@ -165,7 +164,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             SiprecStartRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/siprec_start", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/siprec_start", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -177,7 +176,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             SiprecStopRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/siprec_stop", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/siprec_stop", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -189,7 +188,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             StreamingStartRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/streaming_start", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/streaming_start", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -201,7 +200,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
                StreamingStopRequest request,
                CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/streaming_stop", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/streaming_stop", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -213,7 +212,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             NoiseSuppressionStartRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/suppression_start", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/suppression_start", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -225,7 +224,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
                 NoiseSuppressionStopRequest request,
                 CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/suppression_stop", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/suppression_stop", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -237,7 +236,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             TranscriptionStopRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/transcription_stop", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/transcription_stop", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -247,7 +246,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         public async Task<CallCommandsResponse> HangupCall(string callControlId, HangupCallRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/hangup", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/hangup", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
         }
@@ -256,7 +255,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         public async Task<CallCommandsResponse> RejectCall(string callControlId, RejectCallRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/reject", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/reject", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
         }
@@ -265,7 +264,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         public async Task<CallCommandsResponse?> SpeakText(string callControlId, SpeakTextRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/speak", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/speak", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -275,7 +274,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         public async Task<CallCommandsResponse?> PlaybackStart(string callControlId, PlaybackStartRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/playback_start", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/playback_start", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -285,7 +284,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         public async Task<CallCommandsResponse?> StopAudioPlayback(string callControlId,
             StopAudioPlaybackRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/playback_stop", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/playback_stop", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -297,7 +296,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             RecordingStartRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/record_start", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/record_start", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
         }
@@ -308,7 +307,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             RecordPauseRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/record_pause", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/record_pause", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -320,7 +319,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             RecordResumeRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/record_resume", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/record_resume", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -332,7 +331,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             RecordStopRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/record_stop", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/record_stop", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -344,7 +343,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             SendDtmfRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/send_dtmf", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/send_dtmf", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -356,7 +355,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
             SendSipInfoRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/send_sip_info", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/send_sip_info", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -366,7 +365,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         public async Task<CallCommandsResponse?> RemoveCallFromQueue(string callControlId,
             RemoveCallFromQueueRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/leave_queue", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/leave_queue", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);
@@ -376,7 +375,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         public async Task<CallCommandsResponse?> TransferCall(string callControlId, TransferCallRequest request,
             CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}/actions/transfer", Method.Post);
+            var req = new TelnyxRequest($"calls/{callControlId}/actions/transfer", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CallCommandsResponse>(req, cancellationToken);

--- a/TelnyxSharp/Voice/Operations/ProgrammableVoice/CallControlApplicationsOperations.cs
+++ b/TelnyxSharp/Voice/Operations/ProgrammableVoice/CallControlApplicationsOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Voice.Interfaces;
@@ -8,13 +7,13 @@ using TelnyxSharp.Voice.Models.CallControlApplications.Responses;
 
 namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
 {
-    public class CallControlApplicationsOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class CallControlApplicationsOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), ICallControlApplicationsOperations
     {
         /// <inheritdoc />
         public async Task<ListCallControlApplicationsResponse?> List(ListCallControlApplicationsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("call_control_applications")
+            var req = new TelnyxRequest("call_control_applications")
                 .AddPagination(request.PageSize)
                 .AddFilter("filter[application_name][contains]", request.ApplicationNameContains)
                 .AddFilter("filter[outbound.outbound_voice_profile_id]", request.OutboundVoiceProfileId)
@@ -26,7 +25,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<CreateCallControlApplicationResponse?> Create(CreateCallControlApplicationRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("call_control_applications", Method.Post);
+            var req = new TelnyxRequest("call_control_applications", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CreateCallControlApplicationResponse>(req, cancellationToken);
@@ -35,14 +34,14 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<RetrieveCallControlApplicationResponse?> Retrieve(long id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"call_control_applications/{id}");
+            var req = new TelnyxRequest($"call_control_applications/{id}");
             return await ExecuteAsync<RetrieveCallControlApplicationResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<UpdateCallControlApplicationResponse?> Update(long id, UpdateCallControlApplicationRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"call_control_applications/{id}", Method.Patch);
+            var req = new TelnyxRequest($"call_control_applications/{id}", TelnyxMethod.Patch);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
             return await ExecuteAsync<UpdateCallControlApplicationResponse>(req, cancellationToken);
         }
@@ -50,7 +49,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<DeleteCallControlApplicationResponse?> Delete(long id, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"call_control_applications/{id}", Method.Delete);
+            var req = new TelnyxRequest($"call_control_applications/{id}", TelnyxMethod.Delete);
             return await ExecuteAsync<DeleteCallControlApplicationResponse>(req, cancellationToken);
         }
     }

--- a/TelnyxSharp/Voice/Operations/ProgrammableVoice/CallInformationOperations.cs
+++ b/TelnyxSharp/Voice/Operations/ProgrammableVoice/CallInformationOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Voice.Interfaces;
 using TelnyxSharp.Voice.Models.CallInformation.Requests;
@@ -7,20 +6,20 @@ using TelnyxSharp.Voice.Models.CallInformation.Responses;
 
 namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
 {
-    public class CallInformationOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class CallInformationOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), ICallInformationOperations
     {
         /// <inheritdoc />
         public async Task<RetrieveCallResponse?> RetrieveCall(string callControlId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"calls/{callControlId}");
+            var req = new TelnyxRequest($"calls/{callControlId}");
             return await ExecuteAsync<RetrieveCallResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<ListActiveCallsResponse?> ListActiveCalls(string connectionId, ListActiveCallsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"connections/{connectionId}/active_calls")
+            var req = new TelnyxRequest($"connections/{connectionId}/active_calls")
                 .AddFilter("page[limit]", request.PageSize)
                 .AddFilter("page[after]", request.PageAfter)
                 .AddFilter("page[before]", request.PageBefore);

--- a/TelnyxSharp/Voice/Operations/ProgrammableVoice/ConferenceCommandsOperations.cs
+++ b/TelnyxSharp/Voice/Operations/ProgrammableVoice/ConferenceCommandsOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using System.Text.Json;
 using TelnyxSharp.Base;
 using TelnyxSharp.Voice.Interfaces;
@@ -8,13 +7,13 @@ using TelnyxSharp.Voice.Models.ConferenceCommands.Responses;
 
 namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
 {
-    public class ConferenceCommandsOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class ConferenceCommandsOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IConferenceCommandsOperations
     {
         /// <inheritdoc />
         public async Task<CreateConferenceResponse?> Create(CreateConferenceRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("conferences", Method.Post);
+            var req = new TelnyxRequest("conferences", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<CreateConferenceResponse>(req, cancellationToken);
@@ -23,7 +22,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<ListConferencesResponse?> List(ListConferencesRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("conferences")
+            var req = new TelnyxRequest("conferences")
                            .AddFilter("filter[name]", request.Name)
                            .AddFilter("filter[status]", request.Status)
                            .AddPagination(request.PageSize);
@@ -34,14 +33,14 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<RetrieveConferenceResponse?> Retrieve(string conferenceId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"conferences/{conferenceId}");
+            var req = new TelnyxRequest($"conferences/{conferenceId}");
             return await ExecuteAsync<RetrieveConferenceResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<ListConferenceParticipantsResponse?> ListParticipants(string conferenceId, ListConferenceParticipantsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"conferences/{conferenceId}/participants")
+            var req = new TelnyxRequest($"conferences/{conferenceId}/participants")
                         .AddFilter("filter[muted]", request.Muted)
                         .AddFilter("filter[on_hold]", request.OnHold)
                         .AddFilter("filter[whispering]", request.Whispering)
@@ -53,7 +52,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<ConferenceCommandResponse?> JoinConference(string conferenceId, JoinConferenceRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"conferences/{conferenceId}/actions/join", Method.Post);
+            var req = new TelnyxRequest($"conferences/{conferenceId}/actions/join", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<ConferenceCommandResponse>(req, cancellationToken);
@@ -62,7 +61,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<ConferenceCommandResponse?> LeaveConference(string conferenceId, LeaveConferenceRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"conferences/{conferenceId}/actions/leave", Method.Post);
+            var req = new TelnyxRequest($"conferences/{conferenceId}/actions/leave", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<ConferenceCommandResponse>(req, cancellationToken);
@@ -71,7 +70,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<ConferenceCommandResponse?> UpdateConference(string conferenceId, UpdateConferenceRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"conferences/{conferenceId}/actions/update", Method.Post);
+            var req = new TelnyxRequest($"conferences/{conferenceId}/actions/update", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<ConferenceCommandResponse>(req, cancellationToken);
@@ -80,7 +79,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<ConferenceCommandResponse?> MuteParticipants(string conferenceId, MuteConferenceParticipantsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"conferences/{conferenceId}/actions/mute", Method.Post);
+            var req = new TelnyxRequest($"conferences/{conferenceId}/actions/mute", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<ConferenceCommandResponse>(req, cancellationToken);
@@ -89,7 +88,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<ConferenceCommandResponse?> UnmuteParticipants(string conferenceId, UnmuteConferenceParticipantsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"conferences/{conferenceId}/actions/unmute", Method.Post);
+            var req = new TelnyxRequest($"conferences/{conferenceId}/actions/unmute", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<ConferenceCommandResponse>(req, cancellationToken);
@@ -98,7 +97,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<ConferenceCommandResponse?> HoldParticipants(string conferenceId, HoldConferenceParticipantsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"conferences/{conferenceId}/actions/hold", Method.Post);
+            var req = new TelnyxRequest($"conferences/{conferenceId}/actions/hold", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<ConferenceCommandResponse>(req, cancellationToken);
@@ -107,7 +106,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<ConferenceCommandResponse?> UnholdParticipants(string conferenceId, UnholdConferenceParticipantsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"conferences/{conferenceId}/actions/unhold", Method.Post);
+            var req = new TelnyxRequest($"conferences/{conferenceId}/actions/unhold", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<ConferenceCommandResponse>(req, cancellationToken);
@@ -116,7 +115,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<ConferenceCommandResponse?> StartRecording(string conferenceId, StartConferenceRecordingRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"conferences/{conferenceId}/actions/record_start", Method.Post);
+            var req = new TelnyxRequest($"conferences/{conferenceId}/actions/record_start", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<ConferenceCommandResponse>(req, cancellationToken);
@@ -125,7 +124,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<ConferenceCommandResponse?> StopRecording(string conferenceId, StopConferenceRecordingRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"conferences/{conferenceId}/actions/record_stop", Method.Post);
+            var req = new TelnyxRequest($"conferences/{conferenceId}/actions/record_stop", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<ConferenceCommandResponse>(req, cancellationToken);
@@ -134,7 +133,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<ConferenceCommandResponse?> PauseRecording(string conferenceId, PauseConferenceRecordingRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"conferences/{conferenceId}/actions/record_pause", Method.Post);
+            var req = new TelnyxRequest($"conferences/{conferenceId}/actions/record_pause", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<ConferenceCommandResponse>(req, cancellationToken);
@@ -143,7 +142,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<ConferenceCommandResponse?> ResumeRecording(string conferenceId, ResumeConferenceRecordingRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"conferences/{conferenceId}/actions/record_resume", Method.Post);
+            var req = new TelnyxRequest($"conferences/{conferenceId}/actions/record_resume", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<ConferenceCommandResponse>(req, cancellationToken);
@@ -152,7 +151,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<ConferenceCommandResponse?> SpeakTextToParticipants(string conferenceId, SpeakTextToConferenceRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"conferences/{conferenceId}/actions/speak", Method.Post);
+            var req = new TelnyxRequest($"conferences/{conferenceId}/actions/speak", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<ConferenceCommandResponse>(req, cancellationToken);
@@ -161,7 +160,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<ConferenceCommandResponse?> PlayAudioToParticipants(string conferenceId, PlayAudioToConferenceRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"conferences/{conferenceId}/actions/play", Method.Post);
+            var req = new TelnyxRequest($"conferences/{conferenceId}/actions/play", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<ConferenceCommandResponse>(req, cancellationToken);
@@ -170,7 +169,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
         /// <inheritdoc />
         public async Task<ConferenceCommandResponse?> StopAudioToParticipants(string conferenceId, StopAudioToConferenceRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"conferences/{conferenceId}/actions/stop", Method.Post);
+            var req = new TelnyxRequest($"conferences/{conferenceId}/actions/stop", TelnyxMethod.Post);
             req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<ConferenceCommandResponse>(req, cancellationToken);

--- a/TelnyxSharp/Voice/Operations/ProgrammableVoice/DebuggingOperations.cs
+++ b/TelnyxSharp/Voice/Operations/ProgrammableVoice/DebuggingOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Voice.Interfaces;
 using TelnyxSharp.Voice.Models.Debugging.Requests;
@@ -7,13 +6,13 @@ using TelnyxSharp.Voice.Models.Debugging.Responses;
 
 namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
 {
-    internal class DebuggingOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    internal class DebuggingOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IDebuggingOperations
     {
         /// <inheritdoc />
         public async Task<ListCallEventsResponse?> ListCallEvents(ListCallEventsRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest("call_events")
+            var req = new TelnyxRequest("call_events")
             .AddFilter("filter[leg_id]", request.LegId)
             .AddFilter("filter[application_session_id]", request.ApplicationSessionId)
             .AddFilter("filter[connection_id]", request.ConnectionId)

--- a/TelnyxSharp/Voice/Operations/ProgrammableVoice/ProgrammableVoiceOperations.cs
+++ b/TelnyxSharp/Voice/Operations/ProgrammableVoice/ProgrammableVoiceOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Voice.Interfaces;
 
@@ -9,7 +8,7 @@ namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
     /// Implementation of programmable voice operations.
     /// Provides access to call commands and manages resource disposal.
     /// </summary>
-    public class ProgrammableVoiceOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class ProgrammableVoiceOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
         : BaseOperations(client, rateLimitRetryPolicy), IProgrammableVoiceOperations
     {
         /// <summary>

--- a/TelnyxSharp/Voice/Operations/ProgrammableVoice/QueueCommandsOperations.cs
+++ b/TelnyxSharp/Voice/Operations/ProgrammableVoice/QueueCommandsOperations.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Retry;
-using RestSharp;
 using TelnyxSharp.Base;
 using TelnyxSharp.Voice.Interfaces;
 using TelnyxSharp.Voice.Models.QueueCommands.Requests;
@@ -7,28 +6,28 @@ using TelnyxSharp.Voice.Models.QueueCommands.Responses;
 
 namespace TelnyxSharp.Voice.Operations.ProgrammableVoice
 {
-    public class QueueCommandsOperations(IRestClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+    public class QueueCommandsOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
     : BaseOperations(client, rateLimitRetryPolicy), IQueueCommandsOperations
     {
 
         /// <inheritdoc />
         public async Task<RetrieveQueueResponse?> Retrieve(string queueName, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"queues/{queueName}");
+            var req = new TelnyxRequest($"queues/{queueName}");
             return await ExecuteAsync<RetrieveQueueResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<RetrieveCallQueueResponse?> RetrieveQueueCall(string queueName, string callControlId, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"queues/{queueName}/calls/{callControlId}");
+            var req = new TelnyxRequest($"queues/{queueName}/calls/{callControlId}");
             return await ExecuteAsync<RetrieveCallQueueResponse>(req, cancellationToken);
         }
 
         /// <inheritdoc />
         public async Task<RetrieveCallsQueueResponse?> RetrieveQueueCalls(string queueName, RetrieveCallsQueueRequest request, CancellationToken cancellationToken = default)
         {
-            var req = new RestRequest($"queues/{queueName}/calls")
+            var req = new TelnyxRequest($"queues/{queueName}/calls")
                             .AddPagination(request.PageSize);
 
             return await ExecuteAsync<RetrieveCallsQueueResponse>(req, cancellationToken);

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
## Summary

Brings the TelnyxSharp SDK up to SRS platform standards by replacing the **banned RestSharp dependency** with a native `System.Net.Http.HttpClient` transport, bumping to **net10**, migrating tests to **TUnit + Moq**, and standardizing **CI**.

Context: TelnyxSharp is the external API-wrapper SDK consumed as a NuGet package. The audit found two hard standards violations (RestSharp is banned; projects were on net9) plus test-framework and pipeline gaps. RestSharp was woven through 59 files, but a pre-existing extension-method abstraction (`AddFilter`/`AddBody`/`AddPagination`) made the operation-layer migration mechanical.

## Changes

**Core — HttpClient transport**
- New `TelnyxRequest` builder (`TelnyxSharp.Base`) mirroring the RestSharp surface the operation files use; produces a **fresh `HttpRequestMessage` per send**.
- `BaseOperations.ExecuteAsync` rewritten onto `HttpClient`: STJ source-gen deserialization, 429/Polly rate-limit retry, and pagination that **rebuilds a fresh `HttpRequestMessage` per page** (`HttpRequestMessage` can't be reused).
- `TelnyxClient` rewritten (typed v1+v2 clients, Bearer auth); logging interceptor → `DelegatingHandler`; query-builder extensions ported to `TelnyxRequest`.
- All **54 operation files** migrated off RestSharp.

**Framework / packaging**
- All projects (library, Blazor WebRTC, tests) → **net10.0**; csproj copy de-branded.
- RestSharp removed; `Microsoft.Extensions.Http` added.

**Tests**
- xUnit → **TUnit**; Moq re-pinned **4.20.72 → 4.18.4** (SRS pin).
- `RestRequestQueryBuilderTests` ported to `TelnyxRequest`.
- New `WireProtocolTests` covering the hand-written wire path: `BuildHttpRequestMessage` (query assembly, method mapping, JSON body, multipart upload, Content-Type rule), the send path, **fresh-message-per-page pagination**, and 429 retry.

**CI**
- `publish.yml`: setup-dotnet `10.0.x`, unit tests enabled before pack, alpha/main publish flow kept.
- New PR-triggered `ci.yml` (build + unit tests, NuGet caching).

## Verification

- `dotnet build TelnyxSharp.sln -c Release` → **0 errors** (remaining warnings pre-existing).
- `dotnet test` → **83 total, 0 failed, 55 passed, 28 skipped** (skips are integration tests gated on `TELNYX_API_KEY`).
- **Zero** RestSharp references remain (usings or package refs).

## Follow-ups (deliberately out of scope)

- **`IHttpClientFactory`**: RestSharp (the banned dep) is removed, but `TelnyxClient` news up `HttpClient` with a managed handler pipeline rather than `AddHttpClient<>` typed-client DI. Full adoption would change the public ctor model — proposed as a follow-up.
- **AOT-safety**: the reflection-based pagination and reflection JSON serialize calls prevent true native-AOT compatibility. `IsAotCompatible` was **removed** (it surfaced 548 IL2026/IL3050 warnings) rather than left as a false claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
