### PR TITLE
[#159] Add Branded Calling API support

### DIFF
--- a/TelnyxSharp.Tests/BrandedCallingOperationsTests.cs
+++ b/TelnyxSharp.Tests/BrandedCallingOperationsTests.cs
@@ -1,0 +1,640 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Polly;
+using Polly.RateLimit;
+using Polly.Retry;
+using TelnyxSharp.BrandedCalling.Models.Comments.Requests;
+using TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Requests;
+using TelnyxSharp.BrandedCalling.Models.Enterprises;
+using TelnyxSharp.BrandedCalling.Models.Enterprises.Requests;
+using TelnyxSharp.BrandedCalling.Models.InfringementClaims.Requests;
+using TelnyxSharp.BrandedCalling.Models.PhoneNumberBatches.Requests;
+using TelnyxSharp.BrandedCalling.Models.PhoneNumbers.Requests;
+using TelnyxSharp.BrandedCalling.Models.ReferenceData.Requests;
+using TelnyxSharp.BrandedCalling.Models;
+using TelnyxSharp.BrandedCalling.Operations;
+using TelnyxSharp.Enums;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+namespace TelnyxSharp.Tests
+{
+    /// <summary>
+    /// Exercises the Branded Calling operations over a mocked <see cref="HttpMessageHandler"/>:
+    /// URL/method correctness, request body serialization (snake_case, enums, bare-array bodies),
+    /// and response deserialization for representative operations in each tag group.
+    /// These tests run with no TELNYX_API_KEY.
+    /// </summary>
+    public sealed class BrandedCallingOperationsTests
+    {
+        // ---------------------------------------------------------------------
+        // Test infrastructure
+        // ---------------------------------------------------------------------
+
+        /// <summary>
+        /// An <see cref="HttpMessageHandler"/> that returns canned responses from a queue and records
+        /// every outgoing request's URI, method, and body (captured at send time, before disposal).
+        /// </summary>
+        private sealed class RecordingHandler : HttpMessageHandler
+        {
+            private readonly Queue<Func<HttpResponseMessage>> _responses;
+
+            public List<string> SentUris { get; } = new();
+            public List<HttpMethod> SentMethods { get; } = new();
+            public List<string?> SentBodies { get; } = new();
+
+            public RecordingHandler(params Func<HttpResponseMessage>[] responses)
+            {
+                _responses = new Queue<Func<HttpResponseMessage>>(responses);
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                SentUris.Add(request.RequestUri!.ToString());
+                SentMethods.Add(request.Method);
+                SentBodies.Add(request.Content == null
+                    ? null
+                    : await request.Content.ReadAsStringAsync(cancellationToken));
+
+                var factory = _responses.Count > 0
+                    ? _responses.Dequeue()
+                    : throw new InvalidOperationException("RecordingHandler ran out of canned responses.");
+                return factory();
+            }
+        }
+
+        private static HttpResponseMessage Json(HttpStatusCode status, string body)
+            => new(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            };
+
+        private static HttpResponseMessage NoContent()
+            => new(HttpStatusCode.NoContent) { Content = new StringContent(string.Empty) };
+
+        private static HttpClient ClientWith(RecordingHandler handler)
+            => new(handler) { BaseAddress = new Uri("https://api.telnyx.com/v2/") };
+
+        private static AsyncRetryPolicy NoRetryPolicy()
+            => Policy.Handle<RateLimitRejectedException>().RetryAsync(0);
+
+        private static string SinglePageMeta()
+            => "\"meta\":{\"total_pages\":1,\"total_results\":1,\"page_number\":1,\"page_size\":20}";
+
+        // =====================================================================
+        // Enterprises
+        // =====================================================================
+
+        [Test]
+        public async Task Enterprises_List_SendsFilterAndPagination_AndDeserializes()
+        {
+            var body = $"{{\"data\":[{{\"id\":\"ent-1\",\"legal_name\":\"Acme Plumbing LLC\",\"branded_calling_enabled\":true}}],{SinglePageMeta()}}}";
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.OK, body));
+            using var client = ClientWith(handler);
+            var ops = new EnterpriseOperations(client, NoRetryPolicy());
+
+            var result = await ops.List(new ListEnterprisesRequest { LegalName = "Acme", PageSize = 20 });
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Get);
+            var uri = handler.SentUris.Single();
+            await Assert.That(uri).StartsWith("https://api.telnyx.com/v2/enterprises?");
+            await Assert.That(uri).Contains("filter%5Blegal_name%5D%5Bcontains%5D=Acme");
+            await Assert.That(uri).Contains("page%5Bsize%5D=20");
+            await Assert.That(uri).Contains("page%5Bnumber%5D=1");
+
+            await Assert.That(result.IsSuccessful).IsTrue();
+            await Assert.That(result.Data!.Count).IsEqualTo(1);
+            await Assert.That(result.Data![0].Id).IsEqualTo("ent-1");
+            await Assert.That(result.Data![0].LegalName).IsEqualTo("Acme Plumbing LLC");
+            await Assert.That(result.Data![0].BrandedCallingEnabled).IsEqualTo(true);
+            await Assert.That(result.Meta!.TotalResults).IsEqualTo(1);
+        }
+
+        [Test]
+        public async Task Enterprises_Create_PostsSnakeCaseBody_AndDeserializes()
+        {
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.Created,
+                "{\"data\":{\"id\":\"ent-1\",\"legal_name\":\"Acme Plumbing LLC\",\"country_code\":\"US\"}}"));
+            using var client = ClientWith(handler);
+            var ops = new EnterpriseOperations(client, NoRetryPolicy());
+
+            var result = await ops.Create(new CreateEnterpriseRequest
+            {
+                LegalName = "Acme Plumbing LLC",
+                OrganizationType = "commercial",
+                CountryCode = "US",
+                OrganizationContact = new OrganizationContact
+                {
+                    FirstName = "Sam",
+                    Email = "sam@acmeplumbing.example.com",
+                    PhoneNumber = "+13125550000"
+                },
+                OrganizationPhysicalAddress = new PhysicalAddress
+                {
+                    Country = "US",
+                    City = "Chicago",
+                    StreetAddress = "100 Main St"
+                }
+            });
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Post);
+            await Assert.That(handler.SentUris.Single()).IsEqualTo("https://api.telnyx.com/v2/enterprises");
+
+            using var sent = JsonDocument.Parse(handler.SentBodies.Single()!);
+            await Assert.That(sent.RootElement.GetProperty("legal_name").GetString()).IsEqualTo("Acme Plumbing LLC");
+            await Assert.That(sent.RootElement.GetProperty("organization_type").GetString()).IsEqualTo("commercial");
+            await Assert.That(sent.RootElement.GetProperty("organization_contact").GetProperty("first_name").GetString()).IsEqualTo("Sam");
+            await Assert.That(sent.RootElement.GetProperty("organization_physical_address").GetProperty("street_address").GetString()).IsEqualTo("100 Main St");
+            // Null optional fields are omitted (WhenWritingNull).
+            await Assert.That(sent.RootElement.TryGetProperty("dun_bradstreet_number", out _)).IsFalse();
+
+            await Assert.That(result.IsSuccessful).IsTrue();
+            await Assert.That(result.Data!.Id).IsEqualTo("ent-1");
+        }
+
+        [Test]
+        public async Task Enterprises_Delete_SendsDelete_AndHandles204()
+        {
+            var handler = new RecordingHandler(NoContent);
+            using var client = ClientWith(handler);
+            var ops = new EnterpriseOperations(client, NoRetryPolicy());
+
+            var result = await ops.Delete("ent-1");
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Delete);
+            await Assert.That(handler.SentUris.Single()).IsEqualTo("https://api.telnyx.com/v2/enterprises/ent-1");
+            await Assert.That(result.IsSuccessful).IsTrue();
+            await Assert.That(result.StatusCode).IsEqualTo(HttpStatusCode.NoContent);
+        }
+
+        [Test]
+        public async Task Enterprises_ActivateBrandedCalling_PostsToActivationUrl()
+        {
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.OK,
+                "{\"data\":{\"id\":\"ent-1\",\"branded_calling_enabled\":true}}"));
+            using var client = ClientWith(handler);
+            var ops = new EnterpriseOperations(client, NoRetryPolicy());
+
+            var result = await ops.ActivateBrandedCalling("ent-1");
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Post);
+            await Assert.That(handler.SentUris.Single()).IsEqualTo("https://api.telnyx.com/v2/enterprises/ent-1/branded_calling");
+            await Assert.That(result.Data!.BrandedCallingEnabled).IsEqualTo(true);
+        }
+
+        // =====================================================================
+        // Display Identity Records
+        // =====================================================================
+
+        [Test]
+        public async Task Dirs_List_SendsEnumStatusFilterAsSnakeCase()
+        {
+            var body = $"{{\"data\":[{{\"id\":\"dir-1\",\"display_name\":\"Acme Plumbing\",\"status\":\"in_review\"}}],{SinglePageMeta()}}}";
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.OK, body));
+            using var client = ClientWith(handler);
+            var ops = new DisplayIdentityRecordsOperations(client, NoRetryPolicy());
+
+            var result = await ops.List(new ListDirsRequest
+            {
+                Status = DirStatus.InReview,
+                EnterpriseId = "ent-1",
+                DisplayNameContains = "Acme"
+            });
+
+            var uri = handler.SentUris.Single();
+            await Assert.That(uri).StartsWith("https://api.telnyx.com/v2/dir?");
+            await Assert.That(uri).Contains("filter%5Bstatus%5D=in_review");
+            await Assert.That(uri).Contains("filter%5Benterprise_id%5D=ent-1");
+            await Assert.That(uri).Contains("filter%5Bdisplay_name%5D%5Bcontains%5D=Acme");
+
+            await Assert.That(result.Data!.Single().Status).IsEqualTo(DirStatus.InReview);
+        }
+
+        [Test]
+        public async Task Dirs_Create_PostsToEnterpriseScopedUrl_WithCertifications()
+        {
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.Created,
+                "{\"data\":{\"id\":\"dir-1\",\"enterprise_id\":\"ent-1\",\"display_name\":\"Acme Plumbing\",\"status\":\"draft\"}}"));
+            using var client = ClientWith(handler);
+            var ops = new DisplayIdentityRecordsOperations(client, NoRetryPolicy());
+
+            var result = await ops.Create("ent-1", new CreateDirRequest
+            {
+                DisplayName = "Acme Plumbing",
+                CertifyBrandIsAccurate = true,
+                CertifyNoShaftContent = true,
+                CertifyIpOwnership = true,
+                AuthorizerName = "Sam Owner",
+                AuthorizerEmail = "sam@acmeplumbing.example.com",
+                CallReasons = new List<string> { "Appointment reminders" },
+                Documents = new List<DirDocument>
+                {
+                    new() { DocumentId = "doc-1", DocumentType = "business_registration" }
+                }
+            });
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Post);
+            await Assert.That(handler.SentUris.Single()).IsEqualTo("https://api.telnyx.com/v2/enterprises/ent-1/dir");
+
+            using var sent = JsonDocument.Parse(handler.SentBodies.Single()!);
+            await Assert.That(sent.RootElement.GetProperty("display_name").GetString()).IsEqualTo("Acme Plumbing");
+            await Assert.That(sent.RootElement.GetProperty("certify_brand_is_accurate").GetBoolean()).IsTrue();
+            await Assert.That(sent.RootElement.GetProperty("certify_no_shaft_content").GetBoolean()).IsTrue();
+            await Assert.That(sent.RootElement.GetProperty("certify_ip_ownership").GetBoolean()).IsTrue();
+            await Assert.That(sent.RootElement.GetProperty("call_reasons")[0].GetString()).IsEqualTo("Appointment reminders");
+            await Assert.That(sent.RootElement.GetProperty("documents")[0].GetProperty("document_type").GetString()).IsEqualTo("business_registration");
+
+            await Assert.That(result.Data!.Status).IsEqualTo(DirStatus.Draft);
+        }
+
+        [Test]
+        public async Task Dirs_Update_SendsPatchToDirUrl()
+        {
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.OK,
+                "{\"data\":{\"id\":\"dir-1\",\"display_name\":\"New Name\",\"status\":\"draft\"}}"));
+            using var client = ClientWith(handler);
+            var ops = new DisplayIdentityRecordsOperations(client, NoRetryPolicy());
+
+            var result = await ops.Update("dir-1", new UpdateDirRequest { DisplayName = "New Name" });
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Patch);
+            await Assert.That(handler.SentUris.Single()).IsEqualTo("https://api.telnyx.com/v2/dir/dir-1");
+
+            using var sent = JsonDocument.Parse(handler.SentBodies.Single()!);
+            await Assert.That(sent.RootElement.GetProperty("display_name").GetString()).IsEqualTo("New Name");
+            // Unset optional certifications must be omitted, not sent as null/false.
+            await Assert.That(sent.RootElement.TryGetProperty("certify_brand_is_accurate", out _)).IsFalse();
+
+            await Assert.That(result.Data!.DisplayName).IsEqualTo("New Name");
+        }
+
+        [Test]
+        public async Task Dirs_Submit_PostsToSubmitUrl_AndDeserializesDir()
+        {
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.OK,
+                "{\"data\":{\"id\":\"dir-1\",\"status\":\"submitted\",\"submitted_at\":\"2026-04-26T18:07:03.716411Z\"}}"));
+            using var client = ClientWith(handler);
+            var ops = new DisplayIdentityRecordsOperations(client, NoRetryPolicy());
+
+            var result = await ops.Submit("dir-1");
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Post);
+            await Assert.That(handler.SentUris.Single()).IsEqualTo("https://api.telnyx.com/v2/dir/dir-1/submit");
+            await Assert.That(handler.SentBodies.Single()).IsNull();
+            await Assert.That(result.Data!.Status).IsEqualTo(DirStatus.Submitted);
+        }
+
+        [Test]
+        public async Task Dirs_RenderLoa_PostsBody_AndReturnsPdfBytes()
+        {
+            var pdfBytes = Encoding.ASCII.GetBytes("%PDF-1.4 fake-loa");
+            var handler = new RecordingHandler(() =>
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(pdfBytes)
+                };
+                response.Content.Headers.ContentType = new("application/pdf");
+                return response;
+            });
+            using var client = ClientWith(handler);
+            var ops = new DisplayIdentityRecordsOperations(client, NoRetryPolicy());
+
+            var result = await ops.RenderLoa("dir-1", new RenderDirLoaRequest
+            {
+                PhoneNumbers = new List<string> { "+13125550000" },
+                Signature = new LoaSignature { ImageBase64 = "aWcK", SignerName = "Sam Owner" }
+            });
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Post);
+            await Assert.That(handler.SentUris.Single()).IsEqualTo("https://api.telnyx.com/v2/dir/dir-1/loa");
+
+            using var sent = JsonDocument.Parse(handler.SentBodies.Single()!);
+            await Assert.That(sent.RootElement.GetProperty("phone_numbers")[0].GetString()).IsEqualTo("+13125550000");
+            await Assert.That(sent.RootElement.GetProperty("signature").GetProperty("signer_name").GetString()).IsEqualTo("Sam Owner");
+
+            await Assert.That(result.IsSuccessful).IsTrue();
+            await Assert.That(result.Content).IsEquivalentTo(pdfBytes);
+        }
+
+        // =====================================================================
+        // Phone Numbers
+        // =====================================================================
+
+        [Test]
+        public async Task PhoneNumbers_List_SendsStatusAsPlainQueryParameter()
+        {
+            var body = $"{{\"data\":[{{\"id\":\"pn-1\",\"phone_number\":\"+19493253498\",\"status\":\"verified\"}}],{SinglePageMeta()}}}";
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.OK, body));
+            using var client = ClientWith(handler);
+            var ops = new DirPhoneNumberOperations(client, NoRetryPolicy());
+
+            var result = await ops.List("dir-1", new ListDirPhoneNumbersRequest
+            {
+                Status = DirPhoneNumberStatus.Verified
+            });
+
+            var uri = handler.SentUris.Single();
+            await Assert.That(uri).StartsWith("https://api.telnyx.com/v2/dir/dir-1/phone_numbers?");
+            await Assert.That(uri).Contains("status=verified");
+            await Assert.That(result.Data!.Single().Status).IsEqualTo(DirPhoneNumberStatus.Verified);
+        }
+
+        [Test]
+        public async Task PhoneNumbers_Add_PostsNumbersAndDocuments_AndDeserializesBatch()
+        {
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.Created,
+                "{\"data\":[{\"id\":\"pn-1\",\"phone_number\":\"+19493253498\",\"batch_id\":\"batch-1\",\"status\":\"submitted\"}]}"));
+            using var client = ClientWith(handler);
+            var ops = new DirPhoneNumberOperations(client, NoRetryPolicy());
+
+            var result = await ops.Add("dir-1", new AddDirPhoneNumbersRequest
+            {
+                PhoneNumbers = new List<string> { "+19493253498" },
+                Documents = new List<DirDocument>
+                {
+                    new() { DocumentId = "doc-1", DocumentType = "letter_of_authorization" }
+                }
+            });
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Post);
+            await Assert.That(handler.SentUris.Single()).IsEqualTo("https://api.telnyx.com/v2/dir/dir-1/phone_numbers");
+
+            using var sent = JsonDocument.Parse(handler.SentBodies.Single()!);
+            await Assert.That(sent.RootElement.GetProperty("phone_numbers")[0].GetString()).IsEqualTo("+19493253498");
+            await Assert.That(sent.RootElement.GetProperty("documents")[0].GetProperty("document_type").GetString()).IsEqualTo("letter_of_authorization");
+
+            await Assert.That(result.Data!.Single().BatchId).IsEqualTo("batch-1");
+        }
+
+        [Test]
+        public async Task PhoneNumbers_Delete_SendsBody_AndParsesPerNumberErrors()
+        {
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.OK,
+                "{\"data\":[\"+19493253498\"],\"meta\":{\"errors\":[{\"phone_number\":\"+15555550000\",\"code\":\"not_associated\",\"title\":\"Phone number not associated\",\"detail\":\"Phone number not associated with this DIR.\"}]}}"));
+            using var client = ClientWith(handler);
+            var ops = new DirPhoneNumberOperations(client, NoRetryPolicy());
+
+            var result = await ops.Delete("dir-1", new DeleteDirPhoneNumbersRequest
+            {
+                PhoneNumbers = new List<string> { "+19493253498", "+15555550000" }
+            });
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Delete);
+            await Assert.That(handler.SentUris.Single()).IsEqualTo("https://api.telnyx.com/v2/dir/dir-1/phone_numbers");
+
+            using var sent = JsonDocument.Parse(handler.SentBodies.Single()!);
+            await Assert.That(sent.RootElement.GetProperty("phone_numbers").GetArrayLength()).IsEqualTo(2);
+
+            await Assert.That(result.Data!.Single()).IsEqualTo("+19493253498");
+            await Assert.That(result.Meta!.Errors!.Single().Code).IsEqualTo("not_associated");
+        }
+
+        // =====================================================================
+        // Phone Number Batches
+        // =====================================================================
+
+        [Test]
+        public async Task PhoneNumberBatches_Retrieve_SendsGetToBatchUrl_AndDeserializes()
+        {
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.OK,
+                "{\"data\":{\"batch_id\":\"batch-1\",\"dir_id\":\"dir-1\",\"status\":\"in_review\",\"total_count\":2,\"phone_numbers\":[{\"phone_number\":\"+19493253498\",\"status\":\"in_review\"},{\"phone_number\":\"+19493253499\",\"status\":\"in_review\"}]}}"));
+            using var client = ClientWith(handler);
+            var ops = new DirPhoneNumberBatchOperations(client, NoRetryPolicy());
+
+            var result = await ops.Retrieve("dir-1", "batch-1");
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Get);
+            await Assert.That(handler.SentUris.Single()).IsEqualTo("https://api.telnyx.com/v2/dir/dir-1/phone_number_batches/batch-1");
+            await Assert.That(result.Data!.BatchId).IsEqualTo("batch-1");
+            await Assert.That(result.Data!.TotalCount).IsEqualTo(2);
+            await Assert.That(result.Data!.PhoneNumbers!.Count).IsEqualTo(2);
+        }
+
+        [Test]
+        public async Task PhoneNumberBatches_List_SendsStatusFilter()
+        {
+            var body = $"{{\"data\":[{{\"batch_id\":\"batch-1\",\"status\":\"verified\"}}],{SinglePageMeta()}}}";
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.OK, body));
+            using var client = ClientWith(handler);
+            var ops = new DirPhoneNumberBatchOperations(client, NoRetryPolicy());
+
+            var result = await ops.List("dir-1", new ListDirPhoneNumberBatchesRequest
+            {
+                Status = DirPhoneNumberStatus.Verified
+            });
+
+            var uri = handler.SentUris.Single();
+            await Assert.That(uri).StartsWith("https://api.telnyx.com/v2/dir/dir-1/phone_number_batches?");
+            await Assert.That(uri).Contains("filter%5Bstatus%5D=verified");
+            await Assert.That(result.Data!.Single().Status).IsEqualTo(DirPhoneNumberStatus.Verified);
+        }
+
+        // =====================================================================
+        // Comments
+        // =====================================================================
+
+        [Test]
+        public async Task Comments_Create_PostsContent_AndDeserializes()
+        {
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.Created,
+                "{\"data\":{\"id\":\"com-1\",\"entity_type\":\"dir\",\"content\":\"Please re-review.\",\"comment_type\":\"customer_inquiry\",\"author_role\":\"customer\"}}"));
+            using var client = ClientWith(handler);
+            var ops = new DirCommentOperations(client, NoRetryPolicy());
+
+            var result = await ops.Create("dir-1", new CreateDirCommentRequest { Content = "Please re-review." });
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Post);
+            await Assert.That(handler.SentUris.Single()).IsEqualTo("https://api.telnyx.com/v2/dir/dir-1/comments");
+
+            using var sent = JsonDocument.Parse(handler.SentBodies.Single()!);
+            await Assert.That(sent.RootElement.GetProperty("content").GetString()).IsEqualTo("Please re-review.");
+
+            await Assert.That(result.Data!.CommentType).IsEqualTo(DirCommentType.CustomerInquiry);
+        }
+
+        [Test]
+        public async Task Comments_List_SendsCommentTypeAsPlainQueryParameter()
+        {
+            var body = $"{{\"data\":[{{\"id\":\"com-1\",\"comment_type\":\"vetting_comment\"}}],{SinglePageMeta()}}}";
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.OK, body));
+            using var client = ClientWith(handler);
+            var ops = new DirCommentOperations(client, NoRetryPolicy());
+
+            var result = await ops.List("dir-1", new ListDirCommentsRequest
+            {
+                CommentType = DirCommentType.VettingComment
+            });
+
+            var uri = handler.SentUris.Single();
+            await Assert.That(uri).StartsWith("https://api.telnyx.com/v2/dir/dir-1/comments?");
+            await Assert.That(uri).Contains("comment_type=vetting_comment");
+            await Assert.That(result.Data!.Single().CommentType).IsEqualTo(DirCommentType.VettingComment);
+        }
+
+        // =====================================================================
+        // Infringement Claims
+        // =====================================================================
+
+        [Test]
+        public async Task InfringementClaims_Contest_PostsNotesAndDocuments_AndDeserializesClaim()
+        {
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.OK,
+                "{\"data\":{\"id\":\"claim-1\",\"dir_id\":\"dir-1\",\"claim_type\":\"trademark\",\"status\":\"contested\",\"contest_history\":[{\"notes\":\"We own the trademark outright.\",\"document_count\":1}]}}"));
+            using var client = ClientWith(handler);
+            var ops = new InfringementClaimOperations(client, NoRetryPolicy());
+
+            var result = await ops.Contest("claim-1", new ContestInfringementClaimRequest
+            {
+                ContestNotes = "We own the trademark outright.",
+                Documents = new List<DirDocument>
+                {
+                    new() { DocumentId = "doc-1", DocumentType = "trademark_registration" }
+                }
+            });
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Post);
+            await Assert.That(handler.SentUris.Single()).IsEqualTo("https://api.telnyx.com/v2/infringement_claims/claim-1/contest");
+
+            using var sent = JsonDocument.Parse(handler.SentBodies.Single()!);
+            await Assert.That(sent.RootElement.GetProperty("contest_notes").GetString()).IsEqualTo("We own the trademark outright.");
+
+            await Assert.That(result.Data!.Status).IsEqualTo(InfringementClaimStatus.Contested);
+            await Assert.That(result.Data!.ClaimType).IsEqualTo(InfringementClaimType.Trademark);
+            await Assert.That(result.Data!.ContestHistory!.Single().DocumentCount).IsEqualTo(1);
+        }
+
+        [Test]
+        public async Task InfringementClaims_UpdateDirInfringement_SendsPutWithCertifications()
+        {
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.OK,
+                "{\"data\":{\"id\":\"dir-1\",\"status\":\"submitted\"}}"));
+            using var client = ClientWith(handler);
+            var ops = new InfringementClaimOperations(client, NoRetryPolicy());
+
+            var result = await ops.UpdateDirInfringement("dir-1", new UpdateDirInfringementRequest
+            {
+                CertifyNoInfringement = true,
+                CertifyBrandIsAccurate = true,
+                CertifyNoShaftContent = true,
+                CertifyIpOwnership = true,
+                InfringementResolutionNotes = "Renamed the brand and removed the disputed logo."
+            });
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Put);
+            await Assert.That(handler.SentUris.Single()).IsEqualTo("https://api.telnyx.com/v2/dir/dir-1/infringement_update");
+
+            using var sent = JsonDocument.Parse(handler.SentBodies.Single()!);
+            await Assert.That(sent.RootElement.GetProperty("certify_no_infringement").GetBoolean()).IsTrue();
+            await Assert.That(sent.RootElement.GetProperty("infringement_resolution_notes").GetString())
+                .IsEqualTo("Renamed the brand and removed the disputed logo.");
+
+            await Assert.That(result.Data!.Id).IsEqualTo("dir-1");
+        }
+
+        // =====================================================================
+        // Reference Data
+        // =====================================================================
+
+        [Test]
+        public async Task ReferenceData_ValidateCallReasons_PostsBareJsonArray()
+        {
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.OK,
+                "{\"data\":{\"all_pre_approved\":false,\"non_approved_reasons\":[\"Billing inquiries\"],\"requires_manual_vetting\":true}}"));
+            using var client = ClientWith(handler);
+            var ops = new BrandedCallingReferenceOperations(client, NoRetryPolicy());
+
+            var result = await ops.ValidateCallReasons(new ValidateCallReasonsRequest
+            {
+                CallReasons = new List<string> { "Appointment reminders", "Billing inquiries" }
+            });
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Post);
+            await Assert.That(handler.SentUris.Single()).IsEqualTo("https://api.telnyx.com/v2/call_reasons/validate");
+
+            // The wire body must be a bare JSON array of strings, NOT an object.
+            using var sent = JsonDocument.Parse(handler.SentBodies.Single()!);
+            await Assert.That(sent.RootElement.ValueKind).IsEqualTo(JsonValueKind.Array);
+            await Assert.That(sent.RootElement[0].GetString()).IsEqualTo("Appointment reminders");
+
+            await Assert.That(result.Data!.AllPreApproved).IsFalse();
+            await Assert.That(result.Data!.RequiresManualVetting).IsTrue();
+            await Assert.That(result.Data!.NonApprovedReasons!.Single()).IsEqualTo("Billing inquiries");
+        }
+
+        [Test]
+        public async Task ReferenceData_ListDocumentTypes_SendsGetToReferenceUrl()
+        {
+            var body = $"{{\"data\":[{{\"short_name\":\"letter_of_authorization\",\"description\":\"Signed authorization\"}}],{SinglePageMeta()}}}";
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.OK, body));
+            using var client = ClientWith(handler);
+            var ops = new BrandedCallingReferenceOperations(client, NoRetryPolicy());
+
+            var result = await ops.ListDocumentTypes();
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Get);
+            await Assert.That(handler.SentUris.Single()).IsEqualTo("https://api.telnyx.com/v2/dir/document_types");
+            await Assert.That(result.Data!.Single().ShortName).IsEqualTo("letter_of_authorization");
+        }
+
+        [Test]
+        public async Task ReferenceData_ListCallReasons_SendsPagination_AndDeserializes()
+        {
+            var body = $"{{\"data\":[{{\"id\":\"cr-1\",\"reason\":\"Account Alert\",\"description\":\"Alert about account status\"}}],{SinglePageMeta()}}}";
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.OK, body));
+            using var client = ClientWith(handler);
+            var ops = new BrandedCallingReferenceOperations(client, NoRetryPolicy());
+
+            var result = await ops.ListCallReasons(new ListCallReasonsRequest { PageSize = 100 });
+
+            var uri = handler.SentUris.Single();
+            await Assert.That(uri).StartsWith("https://api.telnyx.com/v2/call_reasons?");
+            await Assert.That(uri).Contains("page%5Bsize%5D=100");
+            await Assert.That(result.Data!.Single().Reason).IsEqualTo("Account Alert");
+        }
+
+        // =====================================================================
+        // Terms of Service
+        // =====================================================================
+
+        [Test]
+        public async Task TermsOfService_Agree_PostsToAgreeUrl_AndDeserializesAgreement()
+        {
+            var handler = new RecordingHandler(() => Json(HttpStatusCode.Created,
+                "{\"data\":{\"id\":\"tos-1\",\"terms_version\":\"v1.0.0\",\"version\":\"v1.0.0\",\"product_type\":\"branded_calling\",\"agreed_at\":\"2025-07-10T10:30:00Z\"}}"));
+            using var client = ClientWith(handler);
+            var ops = new BrandedCallingTosOperations(client, NoRetryPolicy());
+
+            var result = await ops.Agree();
+
+            await Assert.That(handler.SentMethods.Single()).IsEqualTo(HttpMethod.Post);
+            await Assert.That(handler.SentUris.Single()).IsEqualTo("https://api.telnyx.com/v2/terms_of_service/branded_calling/agree");
+            await Assert.That(handler.SentBodies.Single()).IsNull();
+            await Assert.That(result.Data!.TermsVersion).IsEqualTo("v1.0.0");
+            await Assert.That(result.Data!.ProductType).IsEqualTo(TosProductType.BrandedCalling);
+        }
+
+        // =====================================================================
+        // Client wiring
+        // =====================================================================
+
+        [Test]
+        public async Task TelnyxClient_ExposesBrandedCallingSection()
+        {
+            using var client = new TelnyxClient("mock_api_key");
+
+            await Assert.That(client.BrandedCalling).IsNotNull();
+            await Assert.That(client.BrandedCalling.Enterprises).IsNotNull();
+            await Assert.That(client.BrandedCalling.DisplayIdentityRecords).IsNotNull();
+            await Assert.That(client.BrandedCalling.PhoneNumbers).IsNotNull();
+            await Assert.That(client.BrandedCalling.PhoneNumberBatches).IsNotNull();
+            await Assert.That(client.BrandedCalling.Comments).IsNotNull();
+            await Assert.That(client.BrandedCalling.InfringementClaims).IsNotNull();
+            await Assert.That(client.BrandedCalling.ReferenceData).IsNotNull();
+            await Assert.That(client.BrandedCalling.TermsOfService).IsNotNull();
+        }
+    }
+}

--- a/TelnyxSharp/Base/ITelnyxClient.cs
+++ b/TelnyxSharp/Base/ITelnyxClient.cs
@@ -1,4 +1,5 @@
-﻿using TelnyxSharp.DetailRecords.Interfaces;
+﻿using TelnyxSharp.BrandedCalling.Interfaces;
+using TelnyxSharp.DetailRecords.Interfaces;
 using TelnyxSharp.Identity.Interfaces;
 using TelnyxSharp.Messaging.Interfaces;
 using TelnyxSharp.Numbers.Interfaces;
@@ -96,6 +97,13 @@ namespace TelnyxSharp.Base
         /// This includes retrieving detailed records related to Telnyx API usage, such as messaging, conferencing, and other product-specific events.
         /// </summary>
         IDetailRecordsOperations DetailRecordsSearch { get; }
+
+        /// <summary>
+        /// Provides operations for the Branded Calling API.
+        /// This includes enterprise registration, Display Identity Records (DIRs), DIR phone
+        /// numbers and batches, comments, infringement claims, reference data, and Terms of Service.
+        /// </summary>
+        IBrandedCallingOperations BrandedCalling { get; }
 
         /// <summary>
         /// Provides operations for interacting with Telnyx v1 endpoints.

--- a/TelnyxSharp/BrandedCalling/Interfaces/IBrandedCallingOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Interfaces/IBrandedCallingOperations.cs
@@ -1,0 +1,53 @@
+namespace TelnyxSharp.BrandedCalling.Interfaces
+{
+    /// <summary>
+    /// Provides operations for the Telnyx Branded Calling API — enterprise registration,
+    /// Display Identity Records (DIRs), DIR phone numbers and batches, comments,
+    /// infringement claims, reference data, and Terms of Service.
+    /// </summary>
+    public interface IBrandedCallingOperations : IDisposable
+    {
+        /// <summary>
+        /// Gets the operations for managing enterprises — the legal entities that represent
+        /// businesses on the Telnyx platform.
+        /// </summary>
+        IEnterpriseOperations Enterprises { get; }
+
+        /// <summary>
+        /// Gets the operations for managing Display Identity Records (DIRs) — the brand
+        /// identities shown to call recipients.
+        /// </summary>
+        IDisplayIdentityRecordsOperations DisplayIdentityRecords { get; }
+
+        /// <summary>
+        /// Gets the operations for managing the phone numbers attached to a DIR.
+        /// </summary>
+        IDirPhoneNumberOperations PhoneNumbers { get; }
+
+        /// <summary>
+        /// Gets the operations for inspecting the phone-number batches of a DIR.
+        /// </summary>
+        IDirPhoneNumberBatchOperations PhoneNumberBatches { get; }
+
+        /// <summary>
+        /// Gets the operations for reading and posting customer-visible comments on a DIR.
+        /// </summary>
+        IDirCommentOperations Comments { get; }
+
+        /// <summary>
+        /// Gets the operations for handling infringement claims filed against a DIR.
+        /// </summary>
+        IInfringementClaimOperations InfringementClaims { get; }
+
+        /// <summary>
+        /// Gets the operations for Branded Calling reference data — the pre-vetted call-reason
+        /// library and the supported document types.
+        /// </summary>
+        IBrandedCallingReferenceOperations ReferenceData { get; }
+
+        /// <summary>
+        /// Gets the operations for the Branded Calling Terms of Service.
+        /// </summary>
+        IBrandedCallingTosOperations TermsOfService { get; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Interfaces/IBrandedCallingReferenceOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Interfaces/IBrandedCallingReferenceOperations.cs
@@ -1,0 +1,35 @@
+using TelnyxSharp.BrandedCalling.Models.ReferenceData.Requests;
+using TelnyxSharp.BrandedCalling.Models.ReferenceData.Responses;
+
+namespace TelnyxSharp.BrandedCalling.Interfaces
+{
+    /// <summary>
+    /// Provides operations for Branded Calling reference data — the pre-vetted call-reason
+    /// library and the supported document types.
+    /// </summary>
+    public interface IBrandedCallingReferenceOperations
+    {
+        /// <summary>
+        /// Lists the pre-vetted call-reason library, paginated.
+        /// </summary>
+        /// <param name="request">The listing request.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<ListCallReasonsResponse> ListCallReasons(ListCallReasonsRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Validates candidate call reasons against the pre-vetted library.
+        /// </summary>
+        /// <param name="request">The candidate call-reason strings.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<ValidateCallReasonsResponse> ValidateCallReasons(ValidateCallReasonsRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists the supported document types for Branded Calling supporting documents.
+        /// </summary>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<ListDirDocumentTypesResponse> ListDocumentTypes(
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Interfaces/IBrandedCallingTosOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Interfaces/IBrandedCallingTosOperations.cs
@@ -1,0 +1,16 @@
+using TelnyxSharp.BrandedCalling.Models.TermsOfService.Responses;
+
+namespace TelnyxSharp.BrandedCalling.Interfaces
+{
+    /// <summary>
+    /// Provides operations for the Branded Calling Terms of Service.
+    /// </summary>
+    public interface IBrandedCallingTosOperations
+    {
+        /// <summary>
+        /// Records the calling user's agreement to the current Branded Calling Terms of Service.
+        /// </summary>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<TosAgreementResponse> Agree(CancellationToken cancellationToken = default);
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Interfaces/IDirCommentOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Interfaces/IDirCommentOperations.cs
@@ -1,0 +1,30 @@
+using TelnyxSharp.BrandedCalling.Models.Comments.Requests;
+using TelnyxSharp.BrandedCalling.Models.Comments.Responses;
+
+namespace TelnyxSharp.BrandedCalling.Interfaces
+{
+    /// <summary>
+    /// Provides operations for reading and posting customer-visible comments on a
+    /// Display Identity Record (DIR).
+    /// </summary>
+    public interface IDirCommentOperations
+    {
+        /// <summary>
+        /// Lists the customer-visible comments on a DIR, paginated.
+        /// </summary>
+        /// <param name="dirId">The DIR id.</param>
+        /// <param name="request">The listing request with optional filters.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<ListDirCommentsResponse> List(string dirId, ListDirCommentsRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Posts a customer comment on a DIR.
+        /// </summary>
+        /// <param name="dirId">The DIR id.</param>
+        /// <param name="request">The comment body.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<DirCommentResponse> Create(string dirId, CreateDirCommentRequest request,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Interfaces/IDirPhoneNumberBatchOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Interfaces/IDirPhoneNumberBatchOperations.cs
@@ -1,0 +1,29 @@
+using TelnyxSharp.BrandedCalling.Models.PhoneNumberBatches.Requests;
+using TelnyxSharp.BrandedCalling.Models.PhoneNumberBatches.Responses;
+
+namespace TelnyxSharp.BrandedCalling.Interfaces
+{
+    /// <summary>
+    /// Provides operations for inspecting the phone-number batches of a Display Identity Record (DIR).
+    /// </summary>
+    public interface IDirPhoneNumberBatchOperations
+    {
+        /// <summary>
+        /// Lists the phone-number batches of a DIR, paginated.
+        /// </summary>
+        /// <param name="dirId">The DIR id.</param>
+        /// <param name="request">The listing request with optional filters.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<ListDirPhoneNumberBatchesResponse> List(string dirId, ListDirPhoneNumberBatchesRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves a single phone-number batch with per-number status.
+        /// </summary>
+        /// <param name="dirId">The DIR id.</param>
+        /// <param name="batchId">The batch id.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<DirPhoneNumberBatchResponse> Retrieve(string dirId, string batchId,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Interfaces/IDirPhoneNumberOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Interfaces/IDirPhoneNumberOperations.cs
@@ -1,0 +1,40 @@
+using TelnyxSharp.BrandedCalling.Models.PhoneNumbers.Requests;
+using TelnyxSharp.BrandedCalling.Models.PhoneNumbers.Responses;
+
+namespace TelnyxSharp.BrandedCalling.Interfaces
+{
+    /// <summary>
+    /// Provides operations for managing the phone numbers attached to a Display Identity Record (DIR).
+    /// </summary>
+    public interface IDirPhoneNumberOperations
+    {
+        /// <summary>
+        /// Lists the phone numbers attached to a DIR, paginated.
+        /// </summary>
+        /// <param name="dirId">The DIR id.</param>
+        /// <param name="request">The listing request with optional filters.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<ListDirPhoneNumbersResponse> List(string dirId, ListDirPhoneNumbersRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Bulk-adds 1-15 phone numbers to a DIR. All numbers are vetted together as a single
+        /// batch; if any number fails, the entire request is rejected.
+        /// </summary>
+        /// <param name="dirId">The DIR id.</param>
+        /// <param name="request">The phone numbers and supporting documents.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<AddDirPhoneNumbersResponse> Add(string dirId, AddDirPhoneNumbersRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Bulk-deletes 1-15 phone numbers from a DIR. Per-number failures are reported in the
+        /// response meta without blocking the call.
+        /// </summary>
+        /// <param name="dirId">The DIR id.</param>
+        /// <param name="request">The phone numbers to remove.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<DeleteDirPhoneNumbersResponse> Delete(string dirId, DeleteDirPhoneNumbersRequest request,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Interfaces/IDisplayIdentityRecordsOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Interfaces/IDisplayIdentityRecordsOperations.cs
@@ -1,0 +1,80 @@
+using TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Requests;
+using TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Responses;
+
+namespace TelnyxSharp.BrandedCalling.Interfaces
+{
+    /// <summary>
+    /// Provides operations for managing Display Identity Records (DIRs) in the Branded Calling API.
+    /// </summary>
+    public interface IDisplayIdentityRecordsOperations
+    {
+        /// <summary>
+        /// Lists DIRs across all enterprises owned by the caller, paginated.
+        /// </summary>
+        /// <param name="request">The listing request with optional filters.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<ListDirsResponse> List(ListDirsRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists the DIRs of a single enterprise, paginated.
+        /// </summary>
+        /// <param name="enterpriseId">The enterprise id.</param>
+        /// <param name="request">The listing request with optional filters.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<ListDirsResponse> ListByEnterprise(string enterpriseId, ListDirsRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a DIR under an enterprise.
+        /// </summary>
+        /// <param name="enterpriseId">The enterprise id.</param>
+        /// <param name="request">The DIR details.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<DirResponse> Create(string enterpriseId, CreateDirRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves a single DIR by id.
+        /// </summary>
+        /// <param name="dirId">The DIR id.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<DirResponse> Retrieve(string dirId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates a DIR. Only the supplied fields are updated.
+        /// </summary>
+        /// <param name="dirId">The DIR id.</param>
+        /// <param name="request">The fields to update.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<DirResponse> Update(string dirId, UpdateDirRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes a DIR.
+        /// </summary>
+        /// <param name="dirId">The DIR id.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<DeleteDirResponse> Delete(string dirId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Submits a DIR for vetting.
+        /// </summary>
+        /// <param name="dirId">The DIR id.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<DirResponse> Submit(string dirId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Generates a pre-filled Letter of Authorization (LOA) PDF for a DIR.
+        /// The rendered PDF bytes are returned on the response.
+        /// </summary>
+        /// <param name="dirId">The DIR id.</param>
+        /// <param name="request">The phone numbers to authorize, plus optional agent and signature blocks.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<RenderDirLoaResponse> RenderLoa(string dirId, RenderDirLoaRequest request,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Interfaces/IEnterpriseOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Interfaces/IEnterpriseOperations.cs
@@ -1,0 +1,60 @@
+using TelnyxSharp.BrandedCalling.Models.Enterprises.Requests;
+using TelnyxSharp.BrandedCalling.Models.Enterprises.Responses;
+
+namespace TelnyxSharp.BrandedCalling.Interfaces
+{
+    /// <summary>
+    /// Provides operations for managing enterprises in the Branded Calling API.
+    /// </summary>
+    public interface IEnterpriseOperations
+    {
+        /// <summary>
+        /// Lists the enterprises owned by the caller, paginated.
+        /// </summary>
+        /// <param name="request">The listing request with optional filters.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<ListEnterprisesResponse> List(ListEnterprisesRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates the legal entity (enterprise) that represents a business on the Telnyx platform.
+        /// </summary>
+        /// <param name="request">The enterprise details.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<EnterpriseResponse> Create(CreateEnterpriseRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves a single enterprise by id.
+        /// </summary>
+        /// <param name="enterpriseId">The enterprise id.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<EnterpriseResponse> Retrieve(string enterpriseId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates an enterprise. Only the supplied fields are updated.
+        /// </summary>
+        /// <param name="enterpriseId">The enterprise id.</param>
+        /// <param name="request">The fields to update.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<EnterpriseResponse> Update(string enterpriseId, UpdateEnterpriseRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes an enterprise.
+        /// </summary>
+        /// <param name="enterpriseId">The enterprise id.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<DeleteEnterpriseResponse> Delete(string enterpriseId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Activates Branded Calling on an enterprise.
+        /// </summary>
+        /// <param name="enterpriseId">The enterprise id.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<EnterpriseResponse> ActivateBrandedCalling(string enterpriseId,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Interfaces/IInfringementClaimOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Interfaces/IInfringementClaimOperations.cs
@@ -1,0 +1,48 @@
+using TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Responses;
+using TelnyxSharp.BrandedCalling.Models.InfringementClaims.Requests;
+using TelnyxSharp.BrandedCalling.Models.InfringementClaims.Responses;
+
+namespace TelnyxSharp.BrandedCalling.Interfaces
+{
+    /// <summary>
+    /// Provides operations for handling infringement claims filed against a Display Identity Record (DIR).
+    /// </summary>
+    public interface IInfringementClaimOperations
+    {
+        /// <summary>
+        /// Lists the infringement claims filed against a DIR, paginated.
+        /// </summary>
+        /// <param name="dirId">The DIR id.</param>
+        /// <param name="request">The listing request.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<ListInfringementClaimsResponse> ListByDir(string dirId, ListInfringementClaimsRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates a DIR in response to an infringement concern, re-certifying the brand
+        /// information and explaining how the concern was addressed.
+        /// </summary>
+        /// <param name="dirId">The DIR id.</param>
+        /// <param name="request">The re-certifications and updated brand fields.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<DirResponse> UpdateDirInfringement(string dirId, UpdateDirInfringementRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves a single infringement claim by id.
+        /// </summary>
+        /// <param name="claimId">The claim id.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<InfringementClaimResponse> Retrieve(string claimId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Contests an infringement claim with supporting evidence.
+        /// </summary>
+        /// <param name="claimId">The claim id.</param>
+        /// <param name="request">The contest notes and supporting documents.</param>
+        /// <param name="cancellationToken">A token to cancel the request, if needed.</param>
+        Task<InfringementClaimResponse> Contest(string claimId, ContestInfringementClaimRequest request,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/Comments/DirComment.cs
+++ b/TelnyxSharp/BrandedCalling/Models/Comments/DirComment.cs
@@ -1,0 +1,59 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Enums;
+
+namespace TelnyxSharp.BrandedCalling.Models.Comments
+{
+    /// <summary>
+    /// Represents a customer-visible comment on a Display Identity Record (DIR).
+    /// </summary>
+    public class DirComment
+    {
+        /// <summary>
+        /// Server-assigned unique identifier of the comment.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        /// <summary>
+        /// Resource the comment is attached to. Always "dir" on this endpoint.
+        /// </summary>
+        [JsonPropertyName("entity_type")]
+        public string? EntityType { get; set; }
+
+        /// <summary>
+        /// The comment body.
+        /// </summary>
+        [JsonPropertyName("content")]
+        public string? Content { get; set; }
+
+        /// <summary>
+        /// Always "customer" on this endpoint — internal-only comments are filtered out.
+        /// </summary>
+        [JsonPropertyName("visibility")]
+        public string? Visibility { get; set; }
+
+        /// <summary>
+        /// Who wrote the comment: "customer" or "admin" (the Telnyx vetting team).
+        /// </summary>
+        [JsonPropertyName("author_role")]
+        public string? AuthorRole { get; set; }
+
+        /// <summary>
+        /// Display name of the author. May be null.
+        /// </summary>
+        [JsonPropertyName("author_name")]
+        public string? AuthorName { get; set; }
+
+        /// <summary>
+        /// Comment categorisation.
+        /// </summary>
+        [JsonPropertyName("comment_type")]
+        public DirCommentType? CommentType { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the comment was created.
+        /// </summary>
+        [JsonPropertyName("created_at")]
+        public string? CreatedAt { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/Comments/Requests/CreateDirCommentRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/Comments/Requests/CreateDirCommentRequest.cs
@@ -1,0 +1,25 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Base;
+
+namespace TelnyxSharp.BrandedCalling.Models.Comments.Requests
+{
+    /// <summary>
+    /// Represents a request to post a customer comment on a Display Identity Record (DIR).
+    /// The server forces the comment type to "customer_inquiry", visibility to "customer", and
+    /// author role to "customer"; clients cannot override these.
+    /// </summary>
+    public class CreateDirCommentRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// Comment body (1-5000 characters). Required.
+        /// </summary>
+        [JsonPropertyName("content")]
+        public string? Content { get; set; }
+
+        /// <summary>
+        /// Optional parent comment id to thread this reply under.
+        /// </summary>
+        [JsonPropertyName("parent_comment_id")]
+        public string? ParentCommentId { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/Comments/Requests/ListDirCommentsRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/Comments/Requests/ListDirCommentsRequest.cs
@@ -1,0 +1,22 @@
+using TelnyxSharp.Base;
+using TelnyxSharp.Enums;
+
+namespace TelnyxSharp.BrandedCalling.Models.Comments.Requests
+{
+    /// <summary>
+    /// Represents a request for listing the customer-visible comments on a Display Identity Record (DIR).
+    /// </summary>
+    public class ListDirCommentsRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// Gets or sets the number of items per page (default 50, maximum 250).
+        /// </summary>
+        public int? PageSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets a filter restricting results to comments of this category.
+        /// Customer-visible categories only: internal-only comments are filtered out regardless.
+        /// </summary>
+        public DirCommentType? CommentType { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/Comments/Responses/DirCommentResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/Comments/Responses/DirCommentResponse.cs
@@ -1,0 +1,11 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.Comments.Responses
+{
+    /// <summary>
+    /// Represents a single-comment response in the Branded Calling API.
+    /// </summary>
+    public class DirCommentResponse : TelnyxResponse<DirComment>
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/Comments/Responses/ListDirCommentsResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/Comments/Responses/ListDirCommentsResponse.cs
@@ -1,0 +1,11 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.Comments.Responses
+{
+    /// <summary>
+    /// Represents the paginated response for listing the customer-visible comments on a DIR.
+    /// </summary>
+    public class ListDirCommentsResponse : TelnyxResponse<List<DirComment>>
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/DirDocument.cs
+++ b/TelnyxSharp/BrandedCalling/Models/DirDocument.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace TelnyxSharp.BrandedCalling.Models
+{
+    /// <summary>
+    /// Represents a supporting document attached to a Branded Calling resource
+    /// (DIR, phone-number batch, or infringement-claim contest).
+    /// </summary>
+    public class DirDocument
+    {
+        /// <summary>
+        /// Id returned by the Telnyx Documents API after the file was uploaded (via POST /v2/documents).
+        /// </summary>
+        [JsonPropertyName("document_id")]
+        public string? DocumentId { get; set; }
+
+        /// <summary>
+        /// Type of supporting document (e.g. "letter_of_authorization", "business_registration").
+        /// The reference list of supported short names is available via the document types endpoint.
+        /// </summary>
+        [JsonPropertyName("document_type")]
+        public string? DocumentType { get; set; }
+
+        /// <summary>
+        /// Optional free-text description of the document (max 255 characters).
+        /// </summary>
+        [JsonPropertyName("description")]
+        public string? Description { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Dir.cs
+++ b/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Dir.cs
@@ -1,0 +1,150 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Enums;
+
+namespace TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords
+{
+    /// <summary>
+    /// Represents a Display Identity Record (DIR) — the brand identity (display name, logo,
+    /// call reasons) shown to call recipients via Branded Calling.
+    /// </summary>
+    public class Dir
+    {
+        /// <summary>
+        /// Server-assigned unique identifier of the DIR.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        /// <summary>
+        /// Identifier of the enterprise this DIR belongs to.
+        /// </summary>
+        [JsonPropertyName("enterprise_id")]
+        public string? EnterpriseId { get; set; }
+
+        /// <summary>
+        /// Name shown to call recipients.
+        /// </summary>
+        [JsonPropertyName("display_name")]
+        public string? DisplayName { get; set; }
+
+        /// <summary>
+        /// True if the organization places calls on behalf of other enterprises (BPO/reseller).
+        /// </summary>
+        [JsonPropertyName("reselling")]
+        public bool? Reselling { get; set; }
+
+        /// <summary>
+        /// Certification that the DIR information is accurate.
+        /// </summary>
+        [JsonPropertyName("certify_brand_is_accurate")]
+        public bool? CertifyBrandIsAccurate { get; set; }
+
+        /// <summary>
+        /// Certification that this DIR is not used for SHAFT content where prohibited.
+        /// </summary>
+        [JsonPropertyName("certify_no_shaft_content")]
+        public bool? CertifyNoShaftContent { get; set; }
+
+        /// <summary>
+        /// Certification of ownership of any logos/trademarks shown.
+        /// </summary>
+        [JsonPropertyName("certify_ip_ownership")]
+        public bool? CertifyIpOwnership { get; set; }
+
+        /// <summary>
+        /// Name of the person at the enterprise who authorized this DIR registration.
+        /// </summary>
+        [JsonPropertyName("authorizer_name")]
+        public string? AuthorizerName { get; set; }
+
+        /// <summary>
+        /// Contact email of the authorizer.
+        /// </summary>
+        [JsonPropertyName("authorizer_email")]
+        public string? AuthorizerEmail { get; set; }
+
+        /// <summary>
+        /// Publicly accessible HTTPS URL to a 256x256 BMP logo.
+        /// </summary>
+        [JsonPropertyName("logo_url")]
+        public string? LogoUrl { get; set; }
+
+        /// <summary>
+        /// Reasons the business calls customers.
+        /// </summary>
+        [JsonPropertyName("call_reasons")]
+        public List<CallReason>? CallReasons { get; set; }
+
+        /// <summary>
+        /// Supporting documents attached to this DIR.
+        /// </summary>
+        [JsonPropertyName("documents")]
+        public List<DirDocument>? Documents { get; set; }
+
+        /// <summary>
+        /// DIR lifecycle status.
+        /// </summary>
+        [JsonPropertyName("status")]
+        public DirStatus? Status { get; set; }
+
+        /// <summary>
+        /// Populated when the status is rejected; cleared on submit or successful approval.
+        /// </summary>
+        [JsonPropertyName("rejection_reasons")]
+        public List<RejectionReason>? RejectionReasons { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the DIR was rejected, if applicable.
+        /// </summary>
+        [JsonPropertyName("rejected_at")]
+        public string? RejectedAt { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the DIR was created.
+        /// </summary>
+        [JsonPropertyName("created_at")]
+        public string? CreatedAt { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the DIR was last updated.
+        /// </summary>
+        [JsonPropertyName("updated_at")]
+        public string? UpdatedAt { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the DIR was submitted for vetting, if applicable.
+        /// </summary>
+        [JsonPropertyName("submitted_at")]
+        public string? SubmittedAt { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the DIR was verified, if applicable.
+        /// </summary>
+        [JsonPropertyName("verified_at")]
+        public string? VerifiedAt { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the DIR's verification expires, if applicable.
+        /// </summary>
+        [JsonPropertyName("expiring_at")]
+        public string? ExpiringAt { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a call reason attached to a DIR.
+    /// </summary>
+    public class CallReason
+    {
+        /// <summary>
+        /// The call reason text (max 64 characters).
+        /// </summary>
+        [JsonPropertyName("reason")]
+        public string? Reason { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the call reason was created.
+        /// </summary>
+        [JsonPropertyName("created_at")]
+        public string? CreatedAt { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Requests/CreateDirRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Requests/CreateDirRequest.cs
@@ -1,0 +1,75 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Base;
+
+namespace TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Requests
+{
+    /// <summary>
+    /// Represents a request to create a Display Identity Record (DIR) under an enterprise.
+    /// </summary>
+    public class CreateDirRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// Name shown to call recipients (1-35 characters, no emoji, not whitespace-only). Required.
+        /// </summary>
+        [JsonPropertyName("display_name")]
+        public string? DisplayName { get; set; }
+
+        /// <summary>
+        /// Set to true if the organization places calls on behalf of other enterprises (BPO/reseller).
+        /// </summary>
+        [JsonPropertyName("reselling")]
+        public bool? Reselling { get; set; }
+
+        /// <summary>
+        /// Certification that the DIR information is accurate. Must be true. Required.
+        /// </summary>
+        [JsonPropertyName("certify_brand_is_accurate")]
+        public bool CertifyBrandIsAccurate { get; set; }
+
+        /// <summary>
+        /// Certification that this DIR is not used for SHAFT content (Sex, Hate, Alcohol, Firearms,
+        /// Tobacco) where prohibited. Must be true. Required.
+        /// </summary>
+        [JsonPropertyName("certify_no_shaft_content")]
+        public bool CertifyNoShaftContent { get; set; }
+
+        /// <summary>
+        /// Certification of ownership of any logos/trademarks shown. Must be true. Required.
+        /// </summary>
+        [JsonPropertyName("certify_ip_ownership")]
+        public bool CertifyIpOwnership { get; set; }
+
+        /// <summary>
+        /// Name of the person at the enterprise authorizing this DIR registration.
+        /// Must be a real individual. Required.
+        /// </summary>
+        [JsonPropertyName("authorizer_name")]
+        public string? AuthorizerName { get; set; }
+
+        /// <summary>
+        /// Contact email of the authorizer. Telnyx may send verification or infringement-notice
+        /// email here; use a monitored mailbox. Required.
+        /// </summary>
+        [JsonPropertyName("authorizer_email")]
+        public string? AuthorizerEmail { get; set; }
+
+        /// <summary>
+        /// Publicly accessible HTTPS URL (max 128 chars) to a 256x256 BMP logo (max 1 MB).
+        /// </summary>
+        [JsonPropertyName("logo_url")]
+        public string? LogoUrl { get; set; }
+
+        /// <summary>
+        /// 1-10 reasons the business calls customers (each max 64 characters).
+        /// Validate phrasing against the call-reason validation endpoint.
+        /// </summary>
+        [JsonPropertyName("call_reasons")]
+        public List<string>? CallReasons { get; set; }
+
+        /// <summary>
+        /// Supporting documents (max 20). Each document id may appear at most once on a DIR.
+        /// </summary>
+        [JsonPropertyName("documents")]
+        public List<DirDocument>? Documents { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Requests/ListDirsRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Requests/ListDirsRequest.cs
@@ -1,0 +1,61 @@
+using TelnyxSharp.Base;
+using TelnyxSharp.Enums;
+
+namespace TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Requests
+{
+    /// <summary>
+    /// Represents a request for listing Display Identity Records (DIRs), either across all
+    /// enterprises or scoped to a single enterprise.
+    /// </summary>
+    public class ListDirsRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// Gets or sets the number of items per page (default 50, maximum 250).
+        /// </summary>
+        public int? PageSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sort field (e.g. "created_at", "display_name", "status").
+        /// Prefix with "-" for descending. Defaults to "-created_at".
+        /// </summary>
+        public string? Sort { get; set; }
+
+        /// <summary>
+        /// Gets or sets a filter on enterprise id.
+        /// Only applies when listing across all enterprises.
+        /// </summary>
+        public string? EnterpriseId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a filter on DIR status.
+        /// </summary>
+        public DirStatus? Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets a case-insensitive partial match filter on display name.
+        /// </summary>
+        public string? DisplayNameContains { get; set; }
+
+        /// <summary>
+        /// Gets or sets a case-insensitive partial match filter on call reason.
+        /// </summary>
+        public string? CallReasonContains { get; set; }
+
+        /// <summary>
+        /// Gets or sets a lower bound (ISO 8601) on the DIR expiration timestamp.
+        /// </summary>
+        public string? ExpiringAtGte { get; set; }
+
+        /// <summary>
+        /// Gets or sets an upper bound (ISO 8601) on the DIR expiration timestamp.
+        /// </summary>
+        public string? ExpiringAtLte { get; set; }
+
+        /// <summary>
+        /// Gets or sets a convenience filter returning DIRs expiring within the next N days (1-365).
+        /// Only applies when listing DIRs for a specific enterprise; mutually exclusive with the
+        /// explicit expiring-at bounds.
+        /// </summary>
+        public int? ExpiringWithinDays { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Requests/RenderDirLoaRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Requests/RenderDirLoaRequest.cs
@@ -1,0 +1,131 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Base;
+
+namespace TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Requests
+{
+    /// <summary>
+    /// Represents a request to render a pre-filled Letter of Authorization (LOA) PDF for a DIR.
+    /// Enterprise identity and the DIR display name are read server-side; the caller supplies the
+    /// telephone numbers to authorize, an optional Authorized Agent block, and an optional signature.
+    /// </summary>
+    public class RenderDirLoaRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// Telephone numbers to authorize on the DIR, in +E164 format. 1-15 per request. Required.
+        /// </summary>
+        [JsonPropertyName("phone_numbers")]
+        public List<string>? PhoneNumbers { get; set; }
+
+        /// <summary>
+        /// Optional. The third-party reseller / partner managing the enterprise's phone numbers.
+        /// Omit when working directly with Telnyx; the LOA marks the Authorized Agent block as N/A.
+        /// </summary>
+        [JsonPropertyName("agent")]
+        public LoaAgent? Agent { get; set; }
+
+        /// <summary>
+        /// Optional. When provided the rendered PDF embeds the signature image, printed name, and
+        /// signed-at date. When absent the PDF is returned unsigned so the customer can sign it
+        /// externally and upload it via the Documents API.
+        /// </summary>
+        [JsonPropertyName("signature")]
+        public LoaSignature? Signature { get; set; }
+    }
+
+    /// <summary>
+    /// Represents the third-party reseller / partner block on a rendered LOA.
+    /// </summary>
+    public class LoaAgent
+    {
+        /// <summary>
+        /// Legal name of the agent (max 200 characters).
+        /// </summary>
+        [JsonPropertyName("legal_name")]
+        public string? LegalName { get; set; }
+
+        /// <summary>
+        /// Optional trading name of the agent (max 200 characters).
+        /// </summary>
+        [JsonPropertyName("dba")]
+        public string? Dba { get; set; }
+
+        /// <summary>
+        /// Street address of the agent.
+        /// </summary>
+        [JsonPropertyName("street_address")]
+        public string? StreetAddress { get; set; }
+
+        /// <summary>
+        /// Optional extended address (e.g. suite number).
+        /// </summary>
+        [JsonPropertyName("extended_address")]
+        public string? ExtendedAddress { get; set; }
+
+        /// <summary>
+        /// City of the agent.
+        /// </summary>
+        [JsonPropertyName("city")]
+        public string? City { get; set; }
+
+        /// <summary>
+        /// State or province of the agent.
+        /// </summary>
+        [JsonPropertyName("administrative_area")]
+        public string? AdministrativeArea { get; set; }
+
+        /// <summary>
+        /// Postal code of the agent.
+        /// </summary>
+        [JsonPropertyName("postal_code")]
+        public string? PostalCode { get; set; }
+
+        /// <summary>
+        /// ISO 3166-1 alpha-2 country code of the agent.
+        /// </summary>
+        [JsonPropertyName("country")]
+        public string? Country { get; set; }
+
+        /// <summary>
+        /// Name of the agent's contact person.
+        /// </summary>
+        [JsonPropertyName("contact_name")]
+        public string? ContactName { get; set; }
+
+        /// <summary>
+        /// Job title of the agent's contact person.
+        /// </summary>
+        [JsonPropertyName("contact_title")]
+        public string? ContactTitle { get; set; }
+
+        /// <summary>
+        /// Email address of the agent's contact person.
+        /// </summary>
+        [JsonPropertyName("contact_email")]
+        public string? ContactEmail { get; set; }
+
+        /// <summary>
+        /// Phone number of the agent's contact person (max 30 characters).
+        /// </summary>
+        [JsonPropertyName("contact_phone")]
+        public string? ContactPhone { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a drawn signature embedded into a rendered LOA PDF.
+    /// </summary>
+    public class LoaSignature
+    {
+        /// <summary>
+        /// PNG image, base64-encoded. Required.
+        /// </summary>
+        [JsonPropertyName("image_base64")]
+        public string? ImageBase64 { get; set; }
+
+        /// <summary>
+        /// Optional printed name of the signer. When absent the rendered PDF falls back to the
+        /// enterprise contact's legal name.
+        /// </summary>
+        [JsonPropertyName("signer_name")]
+        public string? SignerName { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Requests/UpdateDirRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Requests/UpdateDirRequest.cs
@@ -1,0 +1,77 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Base;
+
+namespace TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Requests
+{
+    /// <summary>
+    /// Represents a request to update a Display Identity Record (DIR).
+    /// All fields are optional; only those supplied are updated.
+    /// </summary>
+    public class UpdateDirRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// Name shown to call recipients (1-35 characters, no emoji, not whitespace-only).
+        /// </summary>
+        [JsonPropertyName("display_name")]
+        public string? DisplayName { get; set; }
+
+        /// <summary>
+        /// Set to true if the organization places calls on behalf of other enterprises (BPO/reseller).
+        /// Updating this triggers re-vetting on next submit.
+        /// </summary>
+        [JsonPropertyName("reselling")]
+        public bool? Reselling { get; set; }
+
+        /// <summary>
+        /// Name of the person at the enterprise authorizing this DIR. Must be a real individual.
+        /// </summary>
+        [JsonPropertyName("authorizer_name")]
+        public string? AuthorizerName { get; set; }
+
+        /// <summary>
+        /// Contact email of the authorizer.
+        /// </summary>
+        [JsonPropertyName("authorizer_email")]
+        public string? AuthorizerEmail { get; set; }
+
+        /// <summary>
+        /// Publicly accessible HTTPS URL (max 128 chars) to a 256x256 BMP logo (max 1 MB).
+        /// </summary>
+        [JsonPropertyName("logo_url")]
+        public string? LogoUrl { get; set; }
+
+        /// <summary>
+        /// 1-10 reasons the business calls customers (each max 64 characters).
+        /// </summary>
+        [JsonPropertyName("call_reasons")]
+        public List<string>? CallReasons { get; set; }
+
+        /// <summary>
+        /// Certification that the DIR information is accurate.
+        /// Must be true for the DIR to be submitted for vetting.
+        /// </summary>
+        [JsonPropertyName("certify_brand_is_accurate")]
+        public bool? CertifyBrandIsAccurate { get; set; }
+
+        /// <summary>
+        /// Certification that this DIR is not used for SHAFT content where prohibited.
+        /// Must be true for the DIR to be submitted for vetting.
+        /// </summary>
+        [JsonPropertyName("certify_no_shaft_content")]
+        public bool? CertifyNoShaftContent { get; set; }
+
+        /// <summary>
+        /// Certification of ownership of any logos/trademarks shown.
+        /// Must be true for the DIR to be submitted for vetting.
+        /// </summary>
+        [JsonPropertyName("certify_ip_ownership")]
+        public bool? CertifyIpOwnership { get; set; }
+
+        /// <summary>
+        /// Additional supporting documents to attach (max 20). Append-only: existing documents
+        /// are never removed or replaced, and an empty or omitted list is a no-op.
+        /// </summary>
+        [JsonPropertyName("documents")]
+        public List<DirDocument>? Documents { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Responses/DeleteDirResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Responses/DeleteDirResponse.cs
@@ -1,0 +1,12 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Responses
+{
+    /// <summary>
+    /// Represents the response for deleting a Display Identity Record (DIR).
+    /// The API returns 204 No Content on success.
+    /// </summary>
+    public class DeleteDirResponse : TelnyxResponse
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Responses/DirResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Responses/DirResponse.cs
@@ -1,0 +1,13 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Responses
+{
+    /// <summary>
+    /// Represents a single-DIR response in the Branded Calling API.
+    /// Returned by the create, retrieve, update, submit, and infringement-update operations,
+    /// which all share the same wire shape (a DIR wrapped in a data envelope).
+    /// </summary>
+    public class DirResponse : TelnyxResponse<Dir>
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Responses/ListDirsResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Responses/ListDirsResponse.cs
@@ -1,0 +1,11 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Responses
+{
+    /// <summary>
+    /// Represents the paginated response for listing Display Identity Records (DIRs).
+    /// </summary>
+    public class ListDirsResponse : TelnyxResponse<List<Dir>>
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Responses/RenderDirLoaResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/DisplayIdentityRecords/Responses/RenderDirLoaResponse.cs
@@ -1,0 +1,16 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Responses
+{
+    /// <summary>
+    /// Represents the response for rendering a DIR Letter of Authorization (LOA).
+    /// The API returns the rendered PDF as a binary body, exposed via <see cref="Content"/>.
+    /// </summary>
+    public class RenderDirLoaResponse : TelnyxResponse
+    {
+        /// <summary>
+        /// Gets or sets the rendered LOA PDF bytes. Null when the request failed.
+        /// </summary>
+        public byte[]? Content { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/Enterprises/Enterprise.cs
+++ b/TelnyxSharp/BrandedCalling/Models/Enterprises/Enterprise.cs
@@ -1,0 +1,270 @@
+using System.Text.Json.Serialization;
+
+namespace TelnyxSharp.BrandedCalling.Models.Enterprises
+{
+    /// <summary>
+    /// Represents the public view of an enterprise (the legal entity that represents a business)
+    /// in the Branded Calling API.
+    /// </summary>
+    public class Enterprise
+    {
+        /// <summary>
+        /// Server-assigned unique identifier of the enterprise.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        /// <summary>
+        /// Legal name of the enterprise.
+        /// </summary>
+        [JsonPropertyName("legal_name")]
+        public string? LegalName { get; set; }
+
+        /// <summary>
+        /// Organization category for vetting purposes (e.g. "commercial", "government", "non_profit").
+        /// </summary>
+        [JsonPropertyName("organization_type")]
+        public string? OrganizationType { get; set; }
+
+        /// <summary>
+        /// ISO 3166-1 alpha-2 country code. Currently "US" and "CA" are supported.
+        /// </summary>
+        [JsonPropertyName("country_code")]
+        public string? CountryCode { get; set; }
+
+        /// <summary>
+        /// "enterprise" for an organization registering its own DIRs; "bpo" for a Business Process
+        /// Outsourcer placing calls on behalf of one or more enterprises.
+        /// </summary>
+        [JsonPropertyName("role_type")]
+        public string? RoleType { get; set; }
+
+        /// <summary>
+        /// Website of the enterprise.
+        /// </summary>
+        [JsonPropertyName("website")]
+        public string? Website { get; set; }
+
+        /// <summary>
+        /// US Federal Employer Identification Number ("NN-NNNNNNN") or Canadian equivalent.
+        /// </summary>
+        [JsonPropertyName("fein")]
+        public string? Fein { get; set; }
+
+        /// <summary>
+        /// Industry classification (e.g. "technology", "healthcare").
+        /// </summary>
+        [JsonPropertyName("industry")]
+        public string? Industry { get; set; }
+
+        /// <summary>
+        /// Approximate headcount range (e.g. "51-200").
+        /// </summary>
+        [JsonPropertyName("number_of_employees")]
+        public string? NumberOfEmployees { get; set; }
+
+        /// <summary>
+        /// Legal-entity form (e.g. "corporation", "llc", "partnership", "nonprofit", "other").
+        /// </summary>
+        [JsonPropertyName("organization_legal_type")]
+        public string? OrganizationLegalType { get; set; }
+
+        /// <summary>
+        /// Trading name of the enterprise.
+        /// </summary>
+        [JsonPropertyName("doing_business_as")]
+        public string? DoingBusinessAs { get; set; }
+
+        /// <summary>
+        /// State/province/country of incorporation.
+        /// </summary>
+        [JsonPropertyName("jurisdiction_of_incorporation")]
+        public string? JurisdictionOfIncorporation { get; set; }
+
+        /// <summary>
+        /// Optional free-form string the caller can attach for their own bookkeeping.
+        /// </summary>
+        [JsonPropertyName("customer_reference")]
+        public string? CustomerReference { get; set; }
+
+        /// <summary>
+        /// Optional SIC code for the primary line of business.
+        /// </summary>
+        [JsonPropertyName("primary_business_domain_sic_code")]
+        public string? PrimaryBusinessDomainSicCode { get; set; }
+
+        /// <summary>
+        /// Optional corporate-registration / company-number identifier.
+        /// </summary>
+        [JsonPropertyName("corporate_registration_number")]
+        public string? CorporateRegistrationNumber { get; set; }
+
+        /// <summary>
+        /// Optional professional-license number for regulated industries.
+        /// </summary>
+        [JsonPropertyName("professional_license_number")]
+        public string? ProfessionalLicenseNumber { get; set; }
+
+        /// <summary>
+        /// Optional D-U-N-S Number issued by Dun &amp; Bradstreet.
+        /// </summary>
+        [JsonPropertyName("dun_bradstreet_number")]
+        public string? DunBradstreetNumber { get; set; }
+
+        /// <summary>
+        /// Organization contact details.
+        /// </summary>
+        [JsonPropertyName("organization_contact")]
+        public OrganizationContact? OrganizationContact { get; set; }
+
+        /// <summary>
+        /// Billing contact details.
+        /// </summary>
+        [JsonPropertyName("billing_contact")]
+        public BillingContact? BillingContact { get; set; }
+
+        /// <summary>
+        /// Physical address of the organization.
+        /// </summary>
+        [JsonPropertyName("organization_physical_address")]
+        public PhysicalAddress? OrganizationPhysicalAddress { get; set; }
+
+        /// <summary>
+        /// Billing address of the organization.
+        /// </summary>
+        [JsonPropertyName("billing_address")]
+        public PhysicalAddress? BillingAddress { get; set; }
+
+        /// <summary>
+        /// True once Branded Calling has been activated on this enterprise.
+        /// </summary>
+        [JsonPropertyName("branded_calling_enabled")]
+        public bool? BrandedCallingEnabled { get; set; }
+
+        /// <summary>
+        /// True once Phone Number Reputation has been enabled on this enterprise.
+        /// </summary>
+        [JsonPropertyName("number_reputation_enabled")]
+        public bool? NumberReputationEnabled { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the enterprise was created.
+        /// </summary>
+        [JsonPropertyName("created_at")]
+        public string? CreatedAt { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the enterprise was last updated.
+        /// </summary>
+        [JsonPropertyName("updated_at")]
+        public string? UpdatedAt { get; set; }
+    }
+
+    /// <summary>
+    /// Represents the organization contact for an enterprise registration.
+    /// </summary>
+    public class OrganizationContact
+    {
+        /// <summary>
+        /// First name of the contact.
+        /// </summary>
+        [JsonPropertyName("first_name")]
+        public string? FirstName { get; set; }
+
+        /// <summary>
+        /// Last name of the contact.
+        /// </summary>
+        [JsonPropertyName("last_name")]
+        public string? LastName { get; set; }
+
+        /// <summary>
+        /// Email address of the contact.
+        /// </summary>
+        [JsonPropertyName("email")]
+        public string? Email { get; set; }
+
+        /// <summary>
+        /// Job title of the contact.
+        /// </summary>
+        [JsonPropertyName("job_title")]
+        public string? JobTitle { get; set; }
+
+        /// <summary>
+        /// Phone number of the contact in E.164 format with leading "+".
+        /// </summary>
+        [JsonPropertyName("phone_number")]
+        public string? PhoneNumber { get; set; }
+    }
+
+    /// <summary>
+    /// Represents the billing contact for an enterprise registration.
+    /// </summary>
+    public class BillingContact
+    {
+        /// <summary>
+        /// First name of the contact.
+        /// </summary>
+        [JsonPropertyName("first_name")]
+        public string? FirstName { get; set; }
+
+        /// <summary>
+        /// Last name of the contact.
+        /// </summary>
+        [JsonPropertyName("last_name")]
+        public string? LastName { get; set; }
+
+        /// <summary>
+        /// Email address of the contact.
+        /// </summary>
+        [JsonPropertyName("email")]
+        public string? Email { get; set; }
+
+        /// <summary>
+        /// Phone number of the contact in E.164 format with leading "+".
+        /// </summary>
+        [JsonPropertyName("phone_number")]
+        public string? PhoneNumber { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a physical address used in an enterprise registration.
+    /// </summary>
+    public class PhysicalAddress
+    {
+        /// <summary>
+        /// ISO 3166-1 alpha-2 country code (currently "US" or "CA").
+        /// </summary>
+        [JsonPropertyName("country")]
+        public string? Country { get; set; }
+
+        /// <summary>
+        /// State or province code (e.g. "IL", "ON").
+        /// </summary>
+        [JsonPropertyName("administrative_area")]
+        public string? AdministrativeArea { get; set; }
+
+        /// <summary>
+        /// City name.
+        /// </summary>
+        [JsonPropertyName("city")]
+        public string? City { get; set; }
+
+        /// <summary>
+        /// Postal code.
+        /// </summary>
+        [JsonPropertyName("postal_code")]
+        public string? PostalCode { get; set; }
+
+        /// <summary>
+        /// Street address.
+        /// </summary>
+        [JsonPropertyName("street_address")]
+        public string? StreetAddress { get; set; }
+
+        /// <summary>
+        /// Optional extended address (e.g. suite number).
+        /// </summary>
+        [JsonPropertyName("extended_address")]
+        public string? ExtendedAddress { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/Enterprises/Requests/CreateEnterpriseRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/Enterprises/Requests/CreateEnterpriseRequest.cs
@@ -1,0 +1,133 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Base;
+
+namespace TelnyxSharp.BrandedCalling.Models.Enterprises.Requests
+{
+    /// <summary>
+    /// Represents a request to create an enterprise (the legal entity that represents a business)
+    /// in the Branded Calling API.
+    /// </summary>
+    public class CreateEnterpriseRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// Legal name of the enterprise (3-64 characters). Required.
+        /// </summary>
+        [JsonPropertyName("legal_name")]
+        public string? LegalName { get; set; }
+
+        /// <summary>
+        /// Organization category for vetting purposes: "commercial", "government", or "non_profit". Required.
+        /// </summary>
+        [JsonPropertyName("organization_type")]
+        public string? OrganizationType { get; set; }
+
+        /// <summary>
+        /// ISO 3166-1 alpha-2 country code. Currently "US" and "CA" are supported. Required.
+        /// </summary>
+        [JsonPropertyName("country_code")]
+        public string? CountryCode { get; set; }
+
+        /// <summary>
+        /// "enterprise" for an organization registering its own DIRs; "bpo" for a Business Process
+        /// Outsourcer placing calls on behalf of one or more enterprises. Defaults to "enterprise".
+        /// </summary>
+        [JsonPropertyName("role_type")]
+        public string? RoleType { get; set; }
+
+        /// <summary>
+        /// Website of the enterprise. Required.
+        /// </summary>
+        [JsonPropertyName("website")]
+        public string? Website { get; set; }
+
+        /// <summary>
+        /// US Federal Employer Identification Number ("NN-NNNNNNN") or Canadian equivalent. Required.
+        /// </summary>
+        [JsonPropertyName("fein")]
+        public string? Fein { get; set; }
+
+        /// <summary>
+        /// Industry classification (e.g. "technology", "healthcare"). Required.
+        /// </summary>
+        [JsonPropertyName("industry")]
+        public string? Industry { get; set; }
+
+        /// <summary>
+        /// Approximate headcount range (e.g. "1-10", "51-200", "10001+"). Required.
+        /// </summary>
+        [JsonPropertyName("number_of_employees")]
+        public string? NumberOfEmployees { get; set; }
+
+        /// <summary>
+        /// Legal-entity form: "corporation", "llc", "partnership", "nonprofit", or "other". Required.
+        /// </summary>
+        [JsonPropertyName("organization_legal_type")]
+        public string? OrganizationLegalType { get; set; }
+
+        /// <summary>
+        /// Trading name of the enterprise. Required.
+        /// </summary>
+        [JsonPropertyName("doing_business_as")]
+        public string? DoingBusinessAs { get; set; }
+
+        /// <summary>
+        /// State/province/country of incorporation. Required.
+        /// </summary>
+        [JsonPropertyName("jurisdiction_of_incorporation")]
+        public string? JurisdictionOfIncorporation { get; set; }
+
+        /// <summary>
+        /// Optional free-form string the caller can attach for their own bookkeeping.
+        /// </summary>
+        [JsonPropertyName("customer_reference")]
+        public string? CustomerReference { get; set; }
+
+        /// <summary>
+        /// Optional SIC code for the primary line of business.
+        /// </summary>
+        [JsonPropertyName("primary_business_domain_sic_code")]
+        public string? PrimaryBusinessDomainSicCode { get; set; }
+
+        /// <summary>
+        /// Optional corporate-registration / company-number identifier.
+        /// </summary>
+        [JsonPropertyName("corporate_registration_number")]
+        public string? CorporateRegistrationNumber { get; set; }
+
+        /// <summary>
+        /// Optional professional-license number for regulated industries.
+        /// </summary>
+        [JsonPropertyName("professional_license_number")]
+        public string? ProfessionalLicenseNumber { get; set; }
+
+        /// <summary>
+        /// Optional D-U-N-S Number.
+        /// </summary>
+        [JsonPropertyName("dun_bradstreet_number")]
+        public string? DunBradstreetNumber { get; set; }
+
+        /// <summary>
+        /// Organization contact details. Required.
+        /// </summary>
+        [JsonPropertyName("organization_contact")]
+        public OrganizationContact? OrganizationContact { get; set; }
+
+        /// <summary>
+        /// Billing contact details. Required.
+        /// </summary>
+        [JsonPropertyName("billing_contact")]
+        public BillingContact? BillingContact { get; set; }
+
+        /// <summary>
+        /// Physical address of the organization. Required.
+        /// </summary>
+        [JsonPropertyName("organization_physical_address")]
+        public PhysicalAddress? OrganizationPhysicalAddress { get; set; }
+
+        /// <summary>
+        /// Billing address of the organization. Required.
+        /// </summary>
+        [JsonPropertyName("billing_address")]
+        public PhysicalAddress? BillingAddress { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/Enterprises/Requests/ListEnterprisesRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/Enterprises/Requests/ListEnterprisesRequest.cs
@@ -1,0 +1,20 @@
+using TelnyxSharp.Base;
+
+namespace TelnyxSharp.BrandedCalling.Models.Enterprises.Requests
+{
+    /// <summary>
+    /// Represents a request for listing enterprises in the Branded Calling API.
+    /// </summary>
+    public class ListEnterprisesRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// Gets or sets the number of items per page (default 50, maximum 250).
+        /// </summary>
+        public int? PageSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets a case-insensitive partial match filter on the enterprise legal name.
+        /// </summary>
+        public string? LegalName { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/Enterprises/Requests/UpdateEnterpriseRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/Enterprises/Requests/UpdateEnterpriseRequest.cs
@@ -1,0 +1,114 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Base;
+
+namespace TelnyxSharp.BrandedCalling.Models.Enterprises.Requests
+{
+    /// <summary>
+    /// Represents a request to update an enterprise in the Branded Calling API.
+    /// All fields are optional; only the ones supplied are updated.
+    /// </summary>
+    public class UpdateEnterpriseRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// Legal name of the enterprise (3-64 characters).
+        /// </summary>
+        [JsonPropertyName("legal_name")]
+        public string? LegalName { get; set; }
+
+        /// <summary>
+        /// Website of the enterprise.
+        /// </summary>
+        [JsonPropertyName("website")]
+        public string? Website { get; set; }
+
+        /// <summary>
+        /// US Federal Employer Identification Number ("NN-NNNNNNN") or Canadian equivalent.
+        /// </summary>
+        [JsonPropertyName("fein")]
+        public string? Fein { get; set; }
+
+        /// <summary>
+        /// Industry classification (e.g. "technology", "healthcare").
+        /// </summary>
+        [JsonPropertyName("industry")]
+        public string? Industry { get; set; }
+
+        /// <summary>
+        /// Approximate headcount range (e.g. "51-200").
+        /// </summary>
+        [JsonPropertyName("number_of_employees")]
+        public string? NumberOfEmployees { get; set; }
+
+        /// <summary>
+        /// Legal-entity form (e.g. "corporation", "llc").
+        /// </summary>
+        [JsonPropertyName("organization_legal_type")]
+        public string? OrganizationLegalType { get; set; }
+
+        /// <summary>
+        /// Trading name of the enterprise.
+        /// </summary>
+        [JsonPropertyName("doing_business_as")]
+        public string? DoingBusinessAs { get; set; }
+
+        /// <summary>
+        /// Optional free-form string the caller can attach for their own bookkeeping.
+        /// </summary>
+        [JsonPropertyName("customer_reference")]
+        public string? CustomerReference { get; set; }
+
+        /// <summary>
+        /// Optional SIC code for the primary line of business.
+        /// </summary>
+        [JsonPropertyName("primary_business_domain_sic_code")]
+        public string? PrimaryBusinessDomainSicCode { get; set; }
+
+        /// <summary>
+        /// Optional corporate-registration / company-number identifier.
+        /// </summary>
+        [JsonPropertyName("corporate_registration_number")]
+        public string? CorporateRegistrationNumber { get; set; }
+
+        /// <summary>
+        /// Optional professional-license number for regulated industries.
+        /// </summary>
+        [JsonPropertyName("professional_license_number")]
+        public string? ProfessionalLicenseNumber { get; set; }
+
+        /// <summary>
+        /// Optional D-U-N-S Number.
+        /// </summary>
+        [JsonPropertyName("dun_bradstreet_number")]
+        public string? DunBradstreetNumber { get; set; }
+
+        /// <summary>
+        /// Updated state/province/country of incorporation.
+        /// </summary>
+        [JsonPropertyName("jurisdiction_of_incorporation")]
+        public string? JurisdictionOfIncorporation { get; set; }
+
+        /// <summary>
+        /// Organization contact details.
+        /// </summary>
+        [JsonPropertyName("organization_contact")]
+        public OrganizationContact? OrganizationContact { get; set; }
+
+        /// <summary>
+        /// Billing contact details.
+        /// </summary>
+        [JsonPropertyName("billing_contact")]
+        public BillingContact? BillingContact { get; set; }
+
+        /// <summary>
+        /// Physical address of the organization.
+        /// </summary>
+        [JsonPropertyName("organization_physical_address")]
+        public PhysicalAddress? OrganizationPhysicalAddress { get; set; }
+
+        /// <summary>
+        /// Billing address of the organization.
+        /// </summary>
+        [JsonPropertyName("billing_address")]
+        public PhysicalAddress? BillingAddress { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/Enterprises/Responses/DeleteEnterpriseResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/Enterprises/Responses/DeleteEnterpriseResponse.cs
@@ -1,0 +1,12 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.Enterprises.Responses
+{
+    /// <summary>
+    /// Represents the response for deleting an enterprise in the Branded Calling API.
+    /// The API returns 204 No Content on success.
+    /// </summary>
+    public class DeleteEnterpriseResponse : TelnyxResponse
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/Enterprises/Responses/EnterpriseResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/Enterprises/Responses/EnterpriseResponse.cs
@@ -1,0 +1,13 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.Enterprises.Responses
+{
+    /// <summary>
+    /// Represents a single-enterprise response in the Branded Calling API.
+    /// Returned by the create, retrieve, update, and Branded Calling activation operations,
+    /// which all share the same wire shape (an enterprise wrapped in a data envelope).
+    /// </summary>
+    public class EnterpriseResponse : TelnyxResponse<Enterprise>
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/Enterprises/Responses/ListEnterprisesResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/Enterprises/Responses/ListEnterprisesResponse.cs
@@ -1,0 +1,11 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.Enterprises.Responses
+{
+    /// <summary>
+    /// Represents the paginated response for listing enterprises in the Branded Calling API.
+    /// </summary>
+    public class ListEnterprisesResponse : TelnyxResponse<List<Enterprise>>
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/InfringementClaims/InfringementClaim.cs
+++ b/TelnyxSharp/BrandedCalling/Models/InfringementClaims/InfringementClaim.cs
@@ -1,0 +1,167 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Enums;
+
+namespace TelnyxSharp.BrandedCalling.Models.InfringementClaims
+{
+    /// <summary>
+    /// Represents a trademark/copyright infringement claim filed against a Display Identity Record (DIR).
+    /// </summary>
+    public class InfringementClaim
+    {
+        /// <summary>
+        /// Server-assigned unique identifier of the claim.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        /// <summary>
+        /// Identifier of the DIR the claim is filed against.
+        /// </summary>
+        [JsonPropertyName("dir_id")]
+        public string? DirId { get; set; }
+
+        /// <summary>
+        /// Identifier of the enterprise the DIR belongs to.
+        /// </summary>
+        [JsonPropertyName("enterprise_id")]
+        public string? EnterpriseId { get; set; }
+
+        /// <summary>
+        /// Category of infringement being claimed.
+        /// </summary>
+        [JsonPropertyName("claim_type")]
+        public InfringementClaimType? ClaimType { get; set; }
+
+        /// <summary>
+        /// Description of the alleged infringement (10-2000 characters).
+        /// </summary>
+        [JsonPropertyName("claim_description")]
+        public string? ClaimDescription { get; set; }
+
+        /// <summary>
+        /// Name of the claimant.
+        /// </summary>
+        [JsonPropertyName("claimant_name")]
+        public string? ClaimantName { get; set; }
+
+        /// <summary>
+        /// Contact details of the claimant.
+        /// </summary>
+        [JsonPropertyName("claimant_contact")]
+        public string? ClaimantContact { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the claim was filed.
+        /// </summary>
+        [JsonPropertyName("claim_date")]
+        public string? ClaimDate { get; set; }
+
+        /// <summary>
+        /// Lifecycle status of the claim.
+        /// </summary>
+        [JsonPropertyName("status")]
+        public InfringementClaimStatus? Status { get; set; }
+
+        /// <summary>
+        /// Resolution of the claim. Set only when the status is resolved.
+        /// </summary>
+        [JsonPropertyName("resolution")]
+        public InfringementClaimResolution? Resolution { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the claim was resolved, if applicable.
+        /// </summary>
+        [JsonPropertyName("resolution_date")]
+        public string? ResolutionDate { get; set; }
+
+        /// <summary>
+        /// Notes from the Telnyx team about the resolution.
+        /// </summary>
+        [JsonPropertyName("resolution_notes")]
+        public string? ResolutionNotes { get; set; }
+
+        /// <summary>
+        /// Contest documents aggregated across all customer contest submissions on this claim.
+        /// </summary>
+        [JsonPropertyName("contest_documents")]
+        public List<DirDocument>? ContestDocuments { get; set; }
+
+        /// <summary>
+        /// Per-round submission audit trail. Each entry records one contest submission.
+        /// </summary>
+        [JsonPropertyName("contest_history")]
+        public List<ContestSubmission>? ContestHistory { get; set; }
+
+        /// <summary>
+        /// Snapshot of the DIR the claim is filed against, embedded for convenience.
+        /// </summary>
+        [JsonPropertyName("dir")]
+        public InfringementClaimDirRef? Dir { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the claim was created.
+        /// </summary>
+        [JsonPropertyName("created_at")]
+        public string? CreatedAt { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the claim was last updated.
+        /// </summary>
+        [JsonPropertyName("updated_at")]
+        public string? UpdatedAt { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a snapshot of the DIR an infringement claim is filed against.
+    /// </summary>
+    public class InfringementClaimDirRef
+    {
+        /// <summary>
+        /// Identifier of the DIR.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        /// <summary>
+        /// Display name of the DIR.
+        /// </summary>
+        [JsonPropertyName("display_name")]
+        public string? DisplayName { get; set; }
+
+        /// <summary>
+        /// Identifier of the enterprise the DIR belongs to.
+        /// </summary>
+        [JsonPropertyName("enterprise_id")]
+        public string? EnterpriseId { get; set; }
+
+        /// <summary>
+        /// Lifecycle status of the DIR.
+        /// </summary>
+        [JsonPropertyName("status")]
+        public DirStatus? Status { get; set; }
+    }
+
+    /// <summary>
+    /// Represents one round of customer contest evidence on an infringement claim.
+    /// </summary>
+    public class ContestSubmission
+    {
+        /// <summary>
+        /// The customer's contest notes for this round.
+        /// </summary>
+        [JsonPropertyName("notes")]
+        public string? Notes { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when this round was submitted.
+        /// </summary>
+        [JsonPropertyName("submitted_at")]
+        public string? SubmittedAt { get; set; }
+
+        /// <summary>
+        /// Number of documents attached to this submission round.
+        /// </summary>
+        [JsonPropertyName("document_count")]
+        public int? DocumentCount { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/InfringementClaims/Requests/ContestInfringementClaimRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/InfringementClaims/Requests/ContestInfringementClaimRequest.cs
@@ -1,0 +1,25 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Base;
+
+namespace TelnyxSharp.BrandedCalling.Models.InfringementClaims.Requests
+{
+    /// <summary>
+    /// Represents a request to contest an infringement claim with supporting evidence.
+    /// </summary>
+    public class ContestInfringementClaimRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// The customer's response to the claim (10-2000 characters). Required.
+        /// </summary>
+        [JsonPropertyName("contest_notes")]
+        public string? ContestNotes { get; set; }
+
+        /// <summary>
+        /// Up to 20 supporting documents per submission. Document ids must be unique within
+        /// this submission; documents are aggregated into the claim's contest documents across
+        /// all submissions.
+        /// </summary>
+        [JsonPropertyName("documents")]
+        public List<DirDocument>? Documents { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/InfringementClaims/Requests/ListInfringementClaimsRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/InfringementClaims/Requests/ListInfringementClaimsRequest.cs
@@ -1,0 +1,15 @@
+using TelnyxSharp.Base;
+
+namespace TelnyxSharp.BrandedCalling.Models.InfringementClaims.Requests
+{
+    /// <summary>
+    /// Represents a request for listing the infringement claims filed against a Display Identity Record (DIR).
+    /// </summary>
+    public class ListInfringementClaimsRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// Gets or sets the number of items per page (default 50, maximum 250).
+        /// </summary>
+        public int? PageSize { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/InfringementClaims/Requests/UpdateDirInfringementRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/InfringementClaims/Requests/UpdateDirInfringementRequest.cs
@@ -1,0 +1,67 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Base;
+
+namespace TelnyxSharp.BrandedCalling.Models.InfringementClaims.Requests
+{
+    /// <summary>
+    /// Represents a request to update a DIR in response to an infringement concern,
+    /// re-certifying the brand information and explaining how the concern was addressed.
+    /// </summary>
+    public class UpdateDirInfringementRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// Certification that the DIR does not infringe. Must be true. Required.
+        /// </summary>
+        [JsonPropertyName("certify_no_infringement")]
+        public bool CertifyNoInfringement { get; set; }
+
+        /// <summary>
+        /// Certification that the DIR information is accurate. Must be true. Required.
+        /// </summary>
+        [JsonPropertyName("certify_brand_is_accurate")]
+        public bool CertifyBrandIsAccurate { get; set; }
+
+        /// <summary>
+        /// Certification that this DIR is not used for SHAFT content where prohibited.
+        /// Must be true. Required.
+        /// </summary>
+        [JsonPropertyName("certify_no_shaft_content")]
+        public bool CertifyNoShaftContent { get; set; }
+
+        /// <summary>
+        /// Certification of ownership of any logos/trademarks shown. Must be true. Required.
+        /// </summary>
+        [JsonPropertyName("certify_ip_ownership")]
+        public bool CertifyIpOwnership { get; set; }
+
+        /// <summary>
+        /// Explanation of how the infringement concern was addressed (10-500 characters). Required.
+        /// </summary>
+        [JsonPropertyName("infringement_resolution_notes")]
+        public string? InfringementResolutionNotes { get; set; }
+
+        /// <summary>
+        /// Updated name shown to call recipients (1-35 characters).
+        /// </summary>
+        [JsonPropertyName("display_name")]
+        public string? DisplayName { get; set; }
+
+        /// <summary>
+        /// Updated publicly accessible HTTPS URL (max 128 chars) to a 256x256 BMP logo (max 1 MB).
+        /// </summary>
+        [JsonPropertyName("logo_url")]
+        public string? LogoUrl { get; set; }
+
+        /// <summary>
+        /// Updated reasons the business calls customers (1-10).
+        /// </summary>
+        [JsonPropertyName("call_reasons")]
+        public List<string>? CallReasons { get; set; }
+
+        /// <summary>
+        /// Append-only supporting documents (max 20).
+        /// </summary>
+        [JsonPropertyName("documents")]
+        public List<DirDocument>? Documents { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/InfringementClaims/Responses/InfringementClaimResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/InfringementClaims/Responses/InfringementClaimResponse.cs
@@ -1,0 +1,12 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.InfringementClaims.Responses
+{
+    /// <summary>
+    /// Represents a single infringement-claim response in the Branded Calling API.
+    /// Returned by the retrieve and contest operations, which share the same wire shape.
+    /// </summary>
+    public class InfringementClaimResponse : TelnyxResponse<InfringementClaim>
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/InfringementClaims/Responses/ListInfringementClaimsResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/InfringementClaims/Responses/ListInfringementClaimsResponse.cs
@@ -1,0 +1,11 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.InfringementClaims.Responses
+{
+    /// <summary>
+    /// Represents the paginated response for listing the infringement claims filed against a DIR.
+    /// </summary>
+    public class ListInfringementClaimsResponse : TelnyxResponse<List<InfringementClaim>>
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/PhoneNumberBatches/DirPhoneNumberBatch.cs
+++ b/TelnyxSharp/BrandedCalling/Models/PhoneNumberBatches/DirPhoneNumberBatch.cs
@@ -1,0 +1,68 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Enums;
+using TelnyxSharp.BrandedCalling.Models.PhoneNumbers;
+
+namespace TelnyxSharp.BrandedCalling.Models.PhoneNumberBatches
+{
+    /// <summary>
+    /// Represents a phone-number batch — all numbers added to a DIR in a single bulk-add request.
+    /// Telnyx vets the batch as a unit.
+    /// </summary>
+    public class DirPhoneNumberBatch
+    {
+        /// <summary>
+        /// Server-assigned unique identifier of the batch.
+        /// </summary>
+        [JsonPropertyName("batch_id")]
+        public string? BatchId { get; set; }
+
+        /// <summary>
+        /// Identifier of the DIR the batch belongs to.
+        /// </summary>
+        [JsonPropertyName("dir_id")]
+        public string? DirId { get; set; }
+
+        /// <summary>
+        /// The DIR's display name at the time the batch was read.
+        /// </summary>
+        [JsonPropertyName("dir_display_name")]
+        public string? DirDisplayName { get; set; }
+
+        /// <summary>
+        /// Identifier of the enterprise the DIR belongs to.
+        /// </summary>
+        [JsonPropertyName("enterprise_id")]
+        public string? EnterpriseId { get; set; }
+
+        /// <summary>
+        /// Aggregate batch status. Mirrors the values used on individual phone numbers.
+        /// </summary>
+        [JsonPropertyName("status")]
+        public DirPhoneNumberStatus? Status { get; set; }
+
+        /// <summary>
+        /// Number of phone numbers in this batch.
+        /// </summary>
+        [JsonPropertyName("total_count")]
+        public int? TotalCount { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the batch was created (and implicitly submitted for vetting).
+        /// </summary>
+        [JsonPropertyName("submitted_at")]
+        public string? SubmittedAt { get; set; }
+
+        /// <summary>
+        /// Documents attached to this batch (e.g. a Letter of Authorization).
+        /// Empty when none were supplied at add time.
+        /// </summary>
+        [JsonPropertyName("documents")]
+        public List<DirDocument>? Documents { get; set; }
+
+        /// <summary>
+        /// All phone numbers in this batch, with per-number status.
+        /// </summary>
+        [JsonPropertyName("phone_numbers")]
+        public List<DirPhoneNumber>? PhoneNumbers { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/PhoneNumberBatches/Requests/ListDirPhoneNumberBatchesRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/PhoneNumberBatches/Requests/ListDirPhoneNumberBatchesRequest.cs
@@ -1,0 +1,21 @@
+using TelnyxSharp.Base;
+using TelnyxSharp.Enums;
+
+namespace TelnyxSharp.BrandedCalling.Models.PhoneNumberBatches.Requests
+{
+    /// <summary>
+    /// Represents a request for listing the phone-number batches of a Display Identity Record (DIR).
+    /// </summary>
+    public class ListDirPhoneNumberBatchesRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// Gets or sets the number of items per page (default 50, maximum 250).
+        /// </summary>
+        public int? PageSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets a filter restricting results to batches whose aggregate status equals this value.
+        /// </summary>
+        public DirPhoneNumberStatus? Status { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/PhoneNumberBatches/Responses/DirPhoneNumberBatchResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/PhoneNumberBatches/Responses/DirPhoneNumberBatchResponse.cs
@@ -1,0 +1,11 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.PhoneNumberBatches.Responses
+{
+    /// <summary>
+    /// Represents a single phone-number batch response in the Branded Calling API.
+    /// </summary>
+    public class DirPhoneNumberBatchResponse : TelnyxResponse<DirPhoneNumberBatch>
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/PhoneNumberBatches/Responses/ListDirPhoneNumberBatchesResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/PhoneNumberBatches/Responses/ListDirPhoneNumberBatchesResponse.cs
@@ -1,0 +1,11 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.PhoneNumberBatches.Responses
+{
+    /// <summary>
+    /// Represents the paginated response for listing the phone-number batches of a DIR.
+    /// </summary>
+    public class ListDirPhoneNumberBatchesResponse : TelnyxResponse<List<DirPhoneNumberBatch>>
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/PhoneNumbers/DirPhoneNumber.cs
+++ b/TelnyxSharp/BrandedCalling/Models/PhoneNumbers/DirPhoneNumber.cs
@@ -1,0 +1,77 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Enums;
+
+namespace TelnyxSharp.BrandedCalling.Models.PhoneNumbers
+{
+    /// <summary>
+    /// Represents a phone number attached to a Display Identity Record (DIR) for Branded Calling.
+    /// </summary>
+    public class DirPhoneNumber
+    {
+        /// <summary>
+        /// Server-assigned unique identifier of the DIR phone-number association.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        /// <summary>
+        /// Identifier of the DIR the phone number is attached to.
+        /// </summary>
+        [JsonPropertyName("dir_id")]
+        public string? DirId { get; set; }
+
+        /// <summary>
+        /// Identifier of the enterprise the DIR belongs to.
+        /// </summary>
+        [JsonPropertyName("enterprise_id")]
+        public string? EnterpriseId { get; set; }
+
+        /// <summary>
+        /// Phone number in E.164 format with leading "+".
+        /// </summary>
+        [JsonPropertyName("phone_number")]
+        public string? PhoneNumber { get; set; }
+
+        /// <summary>
+        /// Identifier of the batch this number was vetted as part of.
+        /// </summary>
+        [JsonPropertyName("batch_id")]
+        public string? BatchId { get; set; }
+
+        /// <summary>
+        /// Identifier of the Letter of Authorization document attached to this number's batch.
+        /// </summary>
+        [JsonPropertyName("loa_document_id")]
+        public string? LoaDocumentId { get; set; }
+
+        /// <summary>
+        /// Phone-number lifecycle status.
+        /// </summary>
+        [JsonPropertyName("status")]
+        public DirPhoneNumberStatus? Status { get; set; }
+
+        /// <summary>
+        /// Populated when the status is unsuccessful or permanently rejected.
+        /// </summary>
+        [JsonPropertyName("rejection_reason")]
+        public RejectionReason? RejectionReason { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the association was created.
+        /// </summary>
+        [JsonPropertyName("created_at")]
+        public string? CreatedAt { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the association was last updated.
+        /// </summary>
+        [JsonPropertyName("updated_at")]
+        public string? UpdatedAt { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the number was verified, if applicable.
+        /// </summary>
+        [JsonPropertyName("verified_at")]
+        public string? VerifiedAt { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/PhoneNumbers/Requests/AddDirPhoneNumbersRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/PhoneNumbers/Requests/AddDirPhoneNumbersRequest.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Base;
+
+namespace TelnyxSharp.BrandedCalling.Models.PhoneNumbers.Requests
+{
+    /// <summary>
+    /// Represents a request to bulk-add phone numbers to a Display Identity Record (DIR).
+    /// All numbers in the request are vetted together as a single batch; if any number fails,
+    /// the entire request is rejected.
+    /// </summary>
+    public class AddDirPhoneNumbersRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// 1-15 phone numbers in E.164 format. 10-digit US numbers are auto-prefixed with "1". Required.
+        /// </summary>
+        [JsonPropertyName("phone_numbers")]
+        public List<string>? PhoneNumbers { get; set; }
+
+        /// <summary>
+        /// Supporting documents covering this batch (1-20). At least one entry with document type
+        /// "letter_of_authorization" is required — the LOA authorises Telnyx to register these
+        /// numbers under the DIR. Required.
+        /// </summary>
+        [JsonPropertyName("documents")]
+        public List<DirDocument>? Documents { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/PhoneNumbers/Requests/DeleteDirPhoneNumbersRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/PhoneNumbers/Requests/DeleteDirPhoneNumbersRequest.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Base;
+
+namespace TelnyxSharp.BrandedCalling.Models.PhoneNumbers.Requests
+{
+    /// <summary>
+    /// Represents a request to bulk-delete phone numbers from a Display Identity Record (DIR).
+    /// </summary>
+    public class DeleteDirPhoneNumbersRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// 1-15 phone numbers in E.164 format to remove from the DIR. Required.
+        /// </summary>
+        [JsonPropertyName("phone_numbers")]
+        public List<string>? PhoneNumbers { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/PhoneNumbers/Requests/ListDirPhoneNumbersRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/PhoneNumbers/Requests/ListDirPhoneNumbersRequest.cs
@@ -1,0 +1,21 @@
+using TelnyxSharp.Base;
+using TelnyxSharp.Enums;
+
+namespace TelnyxSharp.BrandedCalling.Models.PhoneNumbers.Requests
+{
+    /// <summary>
+    /// Represents a request for listing the phone numbers attached to a Display Identity Record (DIR).
+    /// </summary>
+    public class ListDirPhoneNumbersRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// Gets or sets the number of items per page (default 50, maximum 250).
+        /// </summary>
+        public int? PageSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets a filter on phone-number status.
+        /// </summary>
+        public DirPhoneNumberStatus? Status { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/PhoneNumbers/Responses/AddDirPhoneNumbersResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/PhoneNumbers/Responses/AddDirPhoneNumbersResponse.cs
@@ -1,0 +1,14 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.PhoneNumbers.Responses
+{
+    /// <summary>
+    /// Represents the response for bulk-adding phone numbers to a DIR (HTTP 201).
+    /// All numbers in the request were accepted into a single new batch; every entry in the data
+    /// list shares the same batch id. This is an all-or-nothing payload: if any number fails,
+    /// the entire request is rejected with HTTP 400.
+    /// </summary>
+    public class AddDirPhoneNumbersResponse : TelnyxResponse<List<DirPhoneNumber>>
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/PhoneNumbers/Responses/DeleteDirPhoneNumbersResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/PhoneNumbers/Responses/DeleteDirPhoneNumbersResponse.cs
@@ -1,0 +1,57 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.PhoneNumbers.Responses
+{
+    /// <summary>
+    /// Represents the partial-success response for bulk-deleting phone numbers from a DIR.
+    /// The data list holds the phone numbers that were soft-deleted; per-number failures that
+    /// did not block the call are reported in the meta errors list. When every number in the
+    /// request fails, the endpoint instead returns 400 with the canonical Telnyx error envelope.
+    /// </summary>
+    public class DeleteDirPhoneNumbersResponse : TelnyxResponse<List<string>, DeleteDirPhoneNumbersMeta>
+    {
+    }
+
+    /// <summary>
+    /// Represents the meta envelope of a bulk phone-number delete response.
+    /// </summary>
+    public class DeleteDirPhoneNumbersMeta
+    {
+        /// <summary>
+        /// Per-number failures that did not block the call.
+        /// </summary>
+        [JsonPropertyName("errors")]
+        public List<DirPhoneNumberItemError>? Errors { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a per-number error returned by the bulk-delete endpoint.
+    /// </summary>
+    public class DirPhoneNumberItemError
+    {
+        /// <summary>
+        /// The phone number the error applies to.
+        /// </summary>
+        [JsonPropertyName("phone_number")]
+        public string? PhoneNumber { get; set; }
+
+        /// <summary>
+        /// Stable per-number error code (currently only "not_associated").
+        /// </summary>
+        [JsonPropertyName("code")]
+        public string? Code { get; set; }
+
+        /// <summary>
+        /// Short human-readable title of the error.
+        /// </summary>
+        [JsonPropertyName("title")]
+        public string? Title { get; set; }
+
+        /// <summary>
+        /// Detailed explanation of the error.
+        /// </summary>
+        [JsonPropertyName("detail")]
+        public string? Detail { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/PhoneNumbers/Responses/ListDirPhoneNumbersResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/PhoneNumbers/Responses/ListDirPhoneNumbersResponse.cs
@@ -1,0 +1,11 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.PhoneNumbers.Responses
+{
+    /// <summary>
+    /// Represents the paginated response for listing the phone numbers attached to a DIR.
+    /// </summary>
+    public class ListDirPhoneNumbersResponse : TelnyxResponse<List<DirPhoneNumber>>
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/ReferenceData/CallReasonReference.cs
+++ b/TelnyxSharp/BrandedCalling/Models/ReferenceData/CallReasonReference.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace TelnyxSharp.BrandedCalling.Models.ReferenceData
+{
+    /// <summary>
+    /// Represents a pre-vetted call-reason library entry.
+    /// </summary>
+    public class CallReasonReference
+    {
+        /// <summary>
+        /// Server-assigned unique identifier of the library entry.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        /// <summary>
+        /// The pre-vetted call-reason text (e.g. "Account Alert").
+        /// </summary>
+        [JsonPropertyName("reason")]
+        public string? Reason { get; set; }
+
+        /// <summary>
+        /// Description of the call reason.
+        /// </summary>
+        [JsonPropertyName("description")]
+        public string? Description { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/ReferenceData/DirDocumentTypeReference.cs
+++ b/TelnyxSharp/BrandedCalling/Models/ReferenceData/DirDocumentTypeReference.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+
+namespace TelnyxSharp.BrandedCalling.Models.ReferenceData
+{
+    /// <summary>
+    /// Represents a supported document type for Branded Calling supporting documents.
+    /// </summary>
+    public class DirDocumentTypeReference
+    {
+        /// <summary>
+        /// Stable identifier passed as the document type when attaching a document
+        /// (e.g. "letter_of_authorization").
+        /// </summary>
+        [JsonPropertyName("short_name")]
+        public string? ShortName { get; set; }
+
+        /// <summary>
+        /// Description of the document type.
+        /// </summary>
+        [JsonPropertyName("description")]
+        public string? Description { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/ReferenceData/Requests/ListCallReasonsRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/ReferenceData/Requests/ListCallReasonsRequest.cs
@@ -1,0 +1,15 @@
+using TelnyxSharp.Base;
+
+namespace TelnyxSharp.BrandedCalling.Models.ReferenceData.Requests
+{
+    /// <summary>
+    /// Represents a request for listing the pre-vetted call-reason library.
+    /// </summary>
+    public class ListCallReasonsRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// Gets or sets the number of items per page (default 50, maximum 250).
+        /// </summary>
+        public int? PageSize { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/ReferenceData/Requests/ValidateCallReasonsRequest.cs
+++ b/TelnyxSharp/BrandedCalling/Models/ReferenceData/Requests/ValidateCallReasonsRequest.cs
@@ -1,0 +1,17 @@
+using TelnyxSharp.Base;
+
+namespace TelnyxSharp.BrandedCalling.Models.ReferenceData.Requests
+{
+    /// <summary>
+    /// Represents a request to validate candidate call reasons against the pre-vetted library.
+    /// The API expects a bare JSON array of strings as the request body; the operation serializes
+    /// <see cref="CallReasons"/> directly (there is no top-level object on the wire).
+    /// </summary>
+    public class ValidateCallReasonsRequest : ITelnyxRequest
+    {
+        /// <summary>
+        /// 1-10 candidate call-reason strings, each at most 64 characters. Required.
+        /// </summary>
+        public List<string>? CallReasons { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/ReferenceData/Responses/ListCallReasonsResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/ReferenceData/Responses/ListCallReasonsResponse.cs
@@ -1,0 +1,11 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.ReferenceData.Responses
+{
+    /// <summary>
+    /// Represents the paginated response for listing the pre-vetted call-reason library.
+    /// </summary>
+    public class ListCallReasonsResponse : TelnyxResponse<List<CallReasonReference>>
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/ReferenceData/Responses/ListDirDocumentTypesResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/ReferenceData/Responses/ListDirDocumentTypesResponse.cs
@@ -1,0 +1,12 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.ReferenceData.Responses
+{
+    /// <summary>
+    /// Represents the response for listing the supported document types for Branded Calling
+    /// supporting documents.
+    /// </summary>
+    public class ListDirDocumentTypesResponse : TelnyxResponse<List<DirDocumentTypeReference>>
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/ReferenceData/Responses/ValidateCallReasonsResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/ReferenceData/Responses/ValidateCallReasonsResponse.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.ReferenceData.Responses
+{
+    /// <summary>
+    /// Represents the response for validating candidate call reasons against the pre-vetted library.
+    /// </summary>
+    public class ValidateCallReasonsResponse : TelnyxResponse<ValidateCallReasonsData>
+    {
+    }
+
+    /// <summary>
+    /// Represents the result of a call-reason validation.
+    /// </summary>
+    public class ValidateCallReasonsData
+    {
+        /// <summary>
+        /// True when every supplied reason matches a pre-vetted entry in the call-reason library.
+        /// </summary>
+        [JsonPropertyName("all_pre_approved")]
+        public bool AllPreApproved { get; set; }
+
+        /// <summary>
+        /// Subset of the input that does not match the pre-vetted library. A DIR can still be
+        /// submitted with these — they will go through manual review.
+        /// </summary>
+        [JsonPropertyName("non_approved_reasons")]
+        public List<string>? NonApprovedReasons { get; set; }
+
+        /// <summary>
+        /// True when at least one supplied reason is not pre-approved.
+        /// </summary>
+        [JsonPropertyName("requires_manual_vetting")]
+        public bool RequiresManualVetting { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/RejectionReason.cs
+++ b/TelnyxSharp/BrandedCalling/Models/RejectionReason.cs
@@ -1,0 +1,35 @@
+using System.Text.Json.Serialization;
+
+namespace TelnyxSharp.BrandedCalling.Models
+{
+    /// <summary>
+    /// Represents a rejection reason attached to a rejected DIR or phone number in the Branded Calling API.
+    /// </summary>
+    public class RejectionReason
+    {
+        /// <summary>
+        /// Stable rejection-reason code (e.g. "documentation_incomplete").
+        /// </summary>
+        [JsonPropertyName("code")]
+        public string? Code { get; set; }
+
+        /// <summary>
+        /// Short human-readable title of the rejection reason.
+        /// </summary>
+        [JsonPropertyName("title")]
+        public string? Title { get; set; }
+
+        /// <summary>
+        /// Detailed explanation of the rejection reason.
+        /// </summary>
+        [JsonPropertyName("detail")]
+        public string? Detail { get; set; }
+
+        /// <summary>
+        /// Customer-visible free-text comment from the Telnyx vetting team.
+        /// Only the first rejection reason carries this; the rest are null.
+        /// </summary>
+        [JsonPropertyName("message")]
+        public string? Message { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/TermsOfService/Responses/TosAgreementResponse.cs
+++ b/TelnyxSharp/BrandedCalling/Models/TermsOfService/Responses/TosAgreementResponse.cs
@@ -1,0 +1,11 @@
+using TelnyxSharp.Models;
+
+namespace TelnyxSharp.BrandedCalling.Models.TermsOfService.Responses
+{
+    /// <summary>
+    /// Represents the response for agreeing to a product's Terms of Service.
+    /// </summary>
+    public class TosAgreementResponse : TelnyxResponse<TosAgreement>
+    {
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Models/TermsOfService/TosAgreement.cs
+++ b/TelnyxSharp/BrandedCalling/Models/TermsOfService/TosAgreement.cs
@@ -1,0 +1,47 @@
+using System.Text.Json.Serialization;
+using TelnyxSharp.Enums;
+
+namespace TelnyxSharp.BrandedCalling.Models.TermsOfService
+{
+    /// <summary>
+    /// Represents a recorded user agreement to a product's Terms of Service.
+    /// </summary>
+    public class TosAgreement
+    {
+        /// <summary>
+        /// Server-assigned unique identifier of the agreement.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        /// <summary>
+        /// Version of the terms that was agreed to (e.g. "v1.0.0").
+        /// </summary>
+        [JsonPropertyName("terms_version")]
+        public string? TermsVersion { get; set; }
+
+        /// <summary>
+        /// Convenience alias of <see cref="TermsVersion"/>. Both keys are present on every response.
+        /// </summary>
+        [JsonPropertyName("version")]
+        public string? Version { get; set; }
+
+        /// <summary>
+        /// Telnyx product the Terms of Service apply to.
+        /// </summary>
+        [JsonPropertyName("product_type")]
+        public TosProductType? ProductType { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the user agreed.
+        /// </summary>
+        [JsonPropertyName("agreed_at")]
+        public string? AgreedAt { get; set; }
+
+        /// <summary>
+        /// ISO 8601 timestamp of when the agreement record was created.
+        /// </summary>
+        [JsonPropertyName("created_at")]
+        public string? CreatedAt { get; set; }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Operations/BrandedCallingOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Operations/BrandedCallingOperations.cs
@@ -1,0 +1,99 @@
+using Polly.Retry;
+using TelnyxSharp.Base;
+using TelnyxSharp.BrandedCalling.Interfaces;
+
+namespace TelnyxSharp.BrandedCalling.Operations
+{
+    /// <summary>
+    /// Provides operations for the Telnyx Branded Calling API, grouping enterprise management,
+    /// Display Identity Records (DIRs), DIR phone numbers and batches, comments, infringement
+    /// claims, reference data, and Terms of Service.
+    /// Implements the <see cref="IBrandedCallingOperations"/> interface.
+    /// </summary>
+    public class BrandedCallingOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+        : BaseOperations(client, rateLimitRetryPolicy), IBrandedCallingOperations
+    {
+        // Lazy initialization for various operations, ensuring thread safety and lazy loading of instances.
+
+        private readonly Lazy<IEnterpriseOperations> _enterprises = new(() =>
+            new EnterpriseOperations(client, rateLimitRetryPolicy),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+        private readonly Lazy<IDisplayIdentityRecordsOperations> _displayIdentityRecords = new(() =>
+            new DisplayIdentityRecordsOperations(client, rateLimitRetryPolicy),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+        private readonly Lazy<IDirPhoneNumberOperations> _phoneNumbers = new(() =>
+            new DirPhoneNumberOperations(client, rateLimitRetryPolicy),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+        private readonly Lazy<IDirPhoneNumberBatchOperations> _phoneNumberBatches = new(() =>
+            new DirPhoneNumberBatchOperations(client, rateLimitRetryPolicy),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+        private readonly Lazy<IDirCommentOperations> _comments = new(() =>
+            new DirCommentOperations(client, rateLimitRetryPolicy),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+        private readonly Lazy<IInfringementClaimOperations> _infringementClaims = new(() =>
+            new InfringementClaimOperations(client, rateLimitRetryPolicy),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+        private readonly Lazy<IBrandedCallingReferenceOperations> _referenceData = new(() =>
+            new BrandedCallingReferenceOperations(client, rateLimitRetryPolicy),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+        private readonly Lazy<IBrandedCallingTosOperations> _termsOfService = new(() =>
+            new BrandedCallingTosOperations(client, rateLimitRetryPolicy),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+        public IEnterpriseOperations Enterprises => _enterprises.Value;
+
+        public IDisplayIdentityRecordsOperations DisplayIdentityRecords => _displayIdentityRecords.Value;
+
+        public IDirPhoneNumberOperations PhoneNumbers => _phoneNumbers.Value;
+
+        public IDirPhoneNumberBatchOperations PhoneNumberBatches => _phoneNumberBatches.Value;
+
+        public IDirCommentOperations Comments => _comments.Value;
+
+        public IInfringementClaimOperations InfringementClaims => _infringementClaims.Value;
+
+        public IBrandedCallingReferenceOperations ReferenceData => _referenceData.Value;
+
+        public IBrandedCallingTosOperations TermsOfService => _termsOfService.Value;
+
+        /// <summary>
+        /// Disposes of all resources and underlying disposable operations.
+        /// Ensures proper cleanup of resources to avoid memory leaks.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_enterprises.IsValueCreated && _enterprises.Value is IDisposable disposableEnterprises)
+                disposableEnterprises.Dispose();
+
+            if (_displayIdentityRecords.IsValueCreated && _displayIdentityRecords.Value is IDisposable disposableDirs)
+                disposableDirs.Dispose();
+
+            if (_phoneNumbers.IsValueCreated && _phoneNumbers.Value is IDisposable disposablePhoneNumbers)
+                disposablePhoneNumbers.Dispose();
+
+            if (_phoneNumberBatches.IsValueCreated && _phoneNumberBatches.Value is IDisposable disposableBatches)
+                disposableBatches.Dispose();
+
+            if (_comments.IsValueCreated && _comments.Value is IDisposable disposableComments)
+                disposableComments.Dispose();
+
+            if (_infringementClaims.IsValueCreated && _infringementClaims.Value is IDisposable disposableClaims)
+                disposableClaims.Dispose();
+
+            if (_referenceData.IsValueCreated && _referenceData.Value is IDisposable disposableReference)
+                disposableReference.Dispose();
+
+            if (_termsOfService.IsValueCreated && _termsOfService.Value is IDisposable disposableTos)
+                disposableTos.Dispose();
+
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Operations/BrandedCallingReferenceOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Operations/BrandedCallingReferenceOperations.cs
@@ -1,0 +1,50 @@
+using Polly.Retry;
+using System.Text.Json;
+using TelnyxSharp.Base;
+using TelnyxSharp.BrandedCalling.Interfaces;
+using TelnyxSharp.BrandedCalling.Models.ReferenceData.Requests;
+using TelnyxSharp.BrandedCalling.Models.ReferenceData.Responses;
+
+namespace TelnyxSharp.BrandedCalling.Operations
+{
+    /// <summary>
+    /// Provides operations for Branded Calling reference data — the pre-vetted call-reason
+    /// library and the supported document types.
+    /// Implements the <see cref="IBrandedCallingReferenceOperations"/> interface.
+    /// </summary>
+    public class BrandedCallingReferenceOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+        : BaseOperations(client, rateLimitRetryPolicy), IBrandedCallingReferenceOperations
+    {
+        /// <inheritdoc />
+        public async Task<ListCallReasonsResponse> ListCallReasons(ListCallReasonsRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest("call_reasons");
+            req.AddPagination(request.PageSize);
+
+            return await ExecuteAsync<ListCallReasonsResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<ValidateCallReasonsResponse> ValidateCallReasons(ValidateCallReasonsRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest("call_reasons/validate", TelnyxMethod.Post);
+
+            // The endpoint expects a bare JSON array of strings, not an object.
+            req.AddBody(JsonSerializer.Serialize(request.CallReasons ?? new List<string>(),
+                TelnyxJsonSerializerContext.Default.Options));
+
+            return await ExecuteAsync<ValidateCallReasonsResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<ListDirDocumentTypesResponse> ListDocumentTypes(
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest("dir/document_types");
+
+            return await ExecuteAsync<ListDirDocumentTypesResponse>(req, cancellationToken);
+        }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Operations/BrandedCallingReferenceOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Operations/BrandedCallingReferenceOperations.cs
@@ -29,10 +29,13 @@ namespace TelnyxSharp.BrandedCalling.Operations
         public async Task<ValidateCallReasonsResponse> ValidateCallReasons(ValidateCallReasonsRequest request,
             CancellationToken cancellationToken = default)
         {
+            if (request.CallReasons == null || request.CallReasons.Count == 0)
+                throw new ArgumentException("CallReasons must contain between 1 and 10 entries.", nameof(request));
+
             var req = new TelnyxRequest("call_reasons/validate", TelnyxMethod.Post);
 
             // The endpoint expects a bare JSON array of strings, not an object.
-            req.AddBody(JsonSerializer.Serialize(request.CallReasons ?? new List<string>(),
+            req.AddBody(JsonSerializer.Serialize(request.CallReasons,
                 TelnyxJsonSerializerContext.Default.Options));
 
             return await ExecuteAsync<ValidateCallReasonsResponse>(req, cancellationToken);

--- a/TelnyxSharp/BrandedCalling/Operations/BrandedCallingTosOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Operations/BrandedCallingTosOperations.cs
@@ -1,0 +1,23 @@
+using Polly.Retry;
+using TelnyxSharp.Base;
+using TelnyxSharp.BrandedCalling.Interfaces;
+using TelnyxSharp.BrandedCalling.Models.TermsOfService.Responses;
+
+namespace TelnyxSharp.BrandedCalling.Operations
+{
+    /// <summary>
+    /// Provides operations for the Branded Calling Terms of Service.
+    /// Implements the <see cref="IBrandedCallingTosOperations"/> interface.
+    /// </summary>
+    public class BrandedCallingTosOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+        : BaseOperations(client, rateLimitRetryPolicy), IBrandedCallingTosOperations
+    {
+        /// <inheritdoc />
+        public async Task<TosAgreementResponse> Agree(CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest("terms_of_service/branded_calling/agree", TelnyxMethod.Post);
+
+            return await ExecuteAsync<TosAgreementResponse>(req, cancellationToken);
+        }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Operations/DirCommentOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Operations/DirCommentOperations.cs
@@ -1,0 +1,38 @@
+using Polly.Retry;
+using System.Text.Json;
+using TelnyxSharp.Base;
+using TelnyxSharp.BrandedCalling.Interfaces;
+using TelnyxSharp.BrandedCalling.Models.Comments.Requests;
+using TelnyxSharp.BrandedCalling.Models.Comments.Responses;
+
+namespace TelnyxSharp.BrandedCalling.Operations
+{
+    /// <summary>
+    /// Provides operations for reading and posting customer-visible comments on a
+    /// Display Identity Record (DIR). Implements the <see cref="IDirCommentOperations"/> interface.
+    /// </summary>
+    public class DirCommentOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+        : BaseOperations(client, rateLimitRetryPolicy), IDirCommentOperations
+    {
+        /// <inheritdoc />
+        public async Task<ListDirCommentsResponse> List(string dirId, ListDirCommentsRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"dir/{dirId}/comments");
+            req.AddFilter("comment_type", request.CommentType);
+            req.AddPagination(request.PageSize);
+
+            return await ExecuteAsync<ListDirCommentsResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<DirCommentResponse> Create(string dirId, CreateDirCommentRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"dir/{dirId}/comments", TelnyxMethod.Post);
+            req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
+
+            return await ExecuteAsync<DirCommentResponse>(req, cancellationToken);
+        }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Operations/DirPhoneNumberBatchOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Operations/DirPhoneNumberBatchOperations.cs
@@ -1,0 +1,36 @@
+using Polly.Retry;
+using TelnyxSharp.Base;
+using TelnyxSharp.BrandedCalling.Interfaces;
+using TelnyxSharp.BrandedCalling.Models.PhoneNumberBatches.Requests;
+using TelnyxSharp.BrandedCalling.Models.PhoneNumberBatches.Responses;
+
+namespace TelnyxSharp.BrandedCalling.Operations
+{
+    /// <summary>
+    /// Provides operations for inspecting the phone-number batches of a Display Identity Record (DIR).
+    /// Implements the <see cref="IDirPhoneNumberBatchOperations"/> interface.
+    /// </summary>
+    public class DirPhoneNumberBatchOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+        : BaseOperations(client, rateLimitRetryPolicy), IDirPhoneNumberBatchOperations
+    {
+        /// <inheritdoc />
+        public async Task<ListDirPhoneNumberBatchesResponse> List(string dirId, ListDirPhoneNumberBatchesRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"dir/{dirId}/phone_number_batches");
+            req.AddFilter("filter[status]", request.Status);
+            req.AddPagination(request.PageSize);
+
+            return await ExecuteAsync<ListDirPhoneNumberBatchesResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<DirPhoneNumberBatchResponse> Retrieve(string dirId, string batchId,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"dir/{dirId}/phone_number_batches/{batchId}");
+
+            return await ExecuteAsync<DirPhoneNumberBatchResponse>(req, cancellationToken);
+        }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Operations/DirPhoneNumberOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Operations/DirPhoneNumberOperations.cs
@@ -1,0 +1,48 @@
+using Polly.Retry;
+using System.Text.Json;
+using TelnyxSharp.Base;
+using TelnyxSharp.BrandedCalling.Interfaces;
+using TelnyxSharp.BrandedCalling.Models.PhoneNumbers.Requests;
+using TelnyxSharp.BrandedCalling.Models.PhoneNumbers.Responses;
+
+namespace TelnyxSharp.BrandedCalling.Operations
+{
+    /// <summary>
+    /// Provides operations for managing the phone numbers attached to a Display Identity Record (DIR).
+    /// Implements the <see cref="IDirPhoneNumberOperations"/> interface.
+    /// </summary>
+    public class DirPhoneNumberOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+        : BaseOperations(client, rateLimitRetryPolicy), IDirPhoneNumberOperations
+    {
+        /// <inheritdoc />
+        public async Task<ListDirPhoneNumbersResponse> List(string dirId, ListDirPhoneNumbersRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"dir/{dirId}/phone_numbers");
+            req.AddFilter("status", request.Status);
+            req.AddPagination(request.PageSize);
+
+            return await ExecuteAsync<ListDirPhoneNumbersResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<AddDirPhoneNumbersResponse> Add(string dirId, AddDirPhoneNumbersRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"dir/{dirId}/phone_numbers", TelnyxMethod.Post);
+            req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
+
+            return await ExecuteAsync<AddDirPhoneNumbersResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<DeleteDirPhoneNumbersResponse> Delete(string dirId, DeleteDirPhoneNumbersRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"dir/{dirId}/phone_numbers", TelnyxMethod.Delete);
+            req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
+
+            return await ExecuteAsync<DeleteDirPhoneNumbersResponse>(req, cancellationToken);
+        }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Operations/DisplayIdentityRecordsOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Operations/DisplayIdentityRecordsOperations.cs
@@ -111,7 +111,7 @@ namespace TelnyxSharp.BrandedCalling.Operations
                 req.AddOrUpdateHeader("X-Correlation-ID", Guid.NewGuid());
 
                 using var requestMessage = req.BuildHttpRequestMessage();
-                var response = await Client.SendAsync(requestMessage, cancellationToken);
+                using var response = await Client.SendAsync(requestMessage, cancellationToken);
 
                 if (response.StatusCode == HttpStatusCode.TooManyRequests)
                 {

--- a/TelnyxSharp/BrandedCalling/Operations/DisplayIdentityRecordsOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Operations/DisplayIdentityRecordsOperations.cs
@@ -113,6 +113,9 @@ namespace TelnyxSharp.BrandedCalling.Operations
                 using var requestMessage = req.BuildHttpRequestMessage();
                 using var response = await Client.SendAsync(requestMessage, cancellationToken);
 
+                // Always drain the body (mirrors ExecuteAsync) so the connection can be reused.
+                var content = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+
                 if (response.StatusCode == HttpStatusCode.TooManyRequests)
                 {
                     string? resetSeconds = null;
@@ -131,7 +134,7 @@ namespace TelnyxSharp.BrandedCalling.Operations
                 };
 
                 if (response.IsSuccessStatusCode)
-                    result.Content = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+                    result.Content = content;
 
                 return result;
             });

--- a/TelnyxSharp/BrandedCalling/Operations/DisplayIdentityRecordsOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Operations/DisplayIdentityRecordsOperations.cs
@@ -1,0 +1,140 @@
+using Polly.RateLimit;
+using Polly.Retry;
+using System.Net;
+using System.Text.Json;
+using TelnyxSharp.Base;
+using TelnyxSharp.BrandedCalling.Interfaces;
+using TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Requests;
+using TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Responses;
+
+namespace TelnyxSharp.BrandedCalling.Operations
+{
+    /// <summary>
+    /// Provides operations for managing Display Identity Records (DIRs) in the Branded Calling API.
+    /// Implements the <see cref="IDisplayIdentityRecordsOperations"/> interface.
+    /// </summary>
+    public class DisplayIdentityRecordsOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+        : BaseOperations(client, rateLimitRetryPolicy), IDisplayIdentityRecordsOperations
+    {
+        /// <inheritdoc />
+        public async Task<ListDirsResponse> List(ListDirsRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest("dir");
+            req.AddFilter("sort", request.Sort);
+            req.AddFilter("filter[enterprise_id]", request.EnterpriseId);
+            req.AddFilter("filter[status]", request.Status);
+            req.AddFilter("filter[display_name][contains]", request.DisplayNameContains);
+            req.AddFilter("filter[call_reason][contains]", request.CallReasonContains);
+            req.AddFilter("filter[expiring_at][gte]", request.ExpiringAtGte);
+            req.AddFilter("filter[expiring_at][lte]", request.ExpiringAtLte);
+            req.AddPagination(request.PageSize);
+
+            return await ExecuteAsync<ListDirsResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<ListDirsResponse> ListByEnterprise(string enterpriseId, ListDirsRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"enterprises/{enterpriseId}/dir");
+            req.AddFilter("sort", request.Sort);
+            req.AddFilter("filter[status]", request.Status);
+            req.AddFilter("filter[display_name][contains]", request.DisplayNameContains);
+            req.AddFilter("filter[call_reason][contains]", request.CallReasonContains);
+            req.AddFilter("filter[expiring_at][gte]", request.ExpiringAtGte);
+            req.AddFilter("filter[expiring_at][lte]", request.ExpiringAtLte);
+            req.AddFilter("filter[expiring_within_days]", request.ExpiringWithinDays);
+            req.AddPagination(request.PageSize);
+
+            return await ExecuteAsync<ListDirsResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<DirResponse> Create(string enterpriseId, CreateDirRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"enterprises/{enterpriseId}/dir", TelnyxMethod.Post);
+            req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
+
+            return await ExecuteAsync<DirResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<DirResponse> Retrieve(string dirId,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"dir/{dirId}");
+
+            return await ExecuteAsync<DirResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<DirResponse> Update(string dirId, UpdateDirRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"dir/{dirId}", TelnyxMethod.Patch);
+            req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
+
+            return await ExecuteAsync<DirResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<DeleteDirResponse> Delete(string dirId,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"dir/{dirId}", TelnyxMethod.Delete);
+
+            return await ExecuteAsync<DeleteDirResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<DirResponse> Submit(string dirId,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"dir/{dirId}/submit", TelnyxMethod.Post);
+
+            return await ExecuteAsync<DirResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<RenderDirLoaResponse> RenderLoa(string dirId, RenderDirLoaRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"dir/{dirId}/loa", TelnyxMethod.Post);
+            req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
+
+            // The LOA endpoint returns the rendered PDF as a binary body (application/pdf),
+            // so the JSON deserialization path in ExecuteAsync does not apply here.
+            return await RateLimitRetryPolicy.ExecuteAsync(async () =>
+            {
+                req.AddOrUpdateHeader("X-Correlation-ID", Guid.NewGuid());
+
+                using var requestMessage = req.BuildHttpRequestMessage();
+                var response = await Client.SendAsync(requestMessage, cancellationToken);
+
+                if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                {
+                    string? resetSeconds = null;
+                    if (response.Headers.TryGetValues("x-ratelimit-reset", out var values))
+                        resetSeconds = values.FirstOrDefault();
+
+                    var delay = int.TryParse(resetSeconds, out var parsedDelay) ? parsedDelay : 1;
+                    throw new RateLimitRejectedException(TimeSpan.FromSeconds(delay));
+                }
+
+                var result = new RenderDirLoaResponse
+                {
+                    StatusCode = response.StatusCode,
+                    IsSuccessful = response.IsSuccessStatusCode,
+                    ErrorMessage = null
+                };
+
+                if (response.IsSuccessStatusCode)
+                    result.Content = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+
+                return result;
+            });
+        }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Operations/EnterpriseOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Operations/EnterpriseOperations.cs
@@ -1,0 +1,75 @@
+using Polly.Retry;
+using System.Text.Json;
+using TelnyxSharp.Base;
+using TelnyxSharp.BrandedCalling.Interfaces;
+using TelnyxSharp.BrandedCalling.Models.Enterprises.Requests;
+using TelnyxSharp.BrandedCalling.Models.Enterprises.Responses;
+
+namespace TelnyxSharp.BrandedCalling.Operations
+{
+    /// <summary>
+    /// Provides operations for managing enterprises in the Branded Calling API.
+    /// Implements the <see cref="IEnterpriseOperations"/> interface.
+    /// </summary>
+    public class EnterpriseOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+        : BaseOperations(client, rateLimitRetryPolicy), IEnterpriseOperations
+    {
+        /// <inheritdoc />
+        public async Task<ListEnterprisesResponse> List(ListEnterprisesRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest("enterprises");
+            req.AddFilter("filter[legal_name][contains]", request.LegalName);
+            req.AddPagination(request.PageSize);
+
+            return await ExecuteAsync<ListEnterprisesResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<EnterpriseResponse> Create(CreateEnterpriseRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest("enterprises", TelnyxMethod.Post);
+            req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
+
+            return await ExecuteAsync<EnterpriseResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<EnterpriseResponse> Retrieve(string enterpriseId,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"enterprises/{enterpriseId}");
+
+            return await ExecuteAsync<EnterpriseResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<EnterpriseResponse> Update(string enterpriseId, UpdateEnterpriseRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"enterprises/{enterpriseId}", TelnyxMethod.Put);
+            req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
+
+            return await ExecuteAsync<EnterpriseResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<DeleteEnterpriseResponse> Delete(string enterpriseId,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"enterprises/{enterpriseId}", TelnyxMethod.Delete);
+
+            return await ExecuteAsync<DeleteEnterpriseResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<EnterpriseResponse> ActivateBrandedCalling(string enterpriseId,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"enterprises/{enterpriseId}/branded_calling", TelnyxMethod.Post);
+
+            return await ExecuteAsync<EnterpriseResponse>(req, cancellationToken);
+        }
+    }
+}

--- a/TelnyxSharp/BrandedCalling/Operations/InfringementClaimOperations.cs
+++ b/TelnyxSharp/BrandedCalling/Operations/InfringementClaimOperations.cs
@@ -1,0 +1,57 @@
+using Polly.Retry;
+using System.Text.Json;
+using TelnyxSharp.Base;
+using TelnyxSharp.BrandedCalling.Interfaces;
+using TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Responses;
+using TelnyxSharp.BrandedCalling.Models.InfringementClaims.Requests;
+using TelnyxSharp.BrandedCalling.Models.InfringementClaims.Responses;
+
+namespace TelnyxSharp.BrandedCalling.Operations
+{
+    /// <summary>
+    /// Provides operations for handling infringement claims filed against a Display Identity Record (DIR).
+    /// Implements the <see cref="IInfringementClaimOperations"/> interface.
+    /// </summary>
+    public class InfringementClaimOperations(HttpClient client, AsyncRetryPolicy rateLimitRetryPolicy)
+        : BaseOperations(client, rateLimitRetryPolicy), IInfringementClaimOperations
+    {
+        /// <inheritdoc />
+        public async Task<ListInfringementClaimsResponse> ListByDir(string dirId, ListInfringementClaimsRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"dir/{dirId}/infringement_claims");
+            req.AddPagination(request.PageSize);
+
+            return await ExecuteAsync<ListInfringementClaimsResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<DirResponse> UpdateDirInfringement(string dirId, UpdateDirInfringementRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"dir/{dirId}/infringement_update", TelnyxMethod.Put);
+            req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
+
+            return await ExecuteAsync<DirResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<InfringementClaimResponse> Retrieve(string claimId,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"infringement_claims/{claimId}");
+
+            return await ExecuteAsync<InfringementClaimResponse>(req, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<InfringementClaimResponse> Contest(string claimId, ContestInfringementClaimRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var req = new TelnyxRequest($"infringement_claims/{claimId}/contest", TelnyxMethod.Post);
+            req.AddBody(JsonSerializer.Serialize(request, TelnyxJsonSerializerContext.Default.Options));
+
+            return await ExecuteAsync<InfringementClaimResponse>(req, cancellationToken);
+        }
+    }
+}

--- a/TelnyxSharp/Enums/DirCommentType.cs
+++ b/TelnyxSharp/Enums/DirCommentType.cs
@@ -1,0 +1,54 @@
+using System.Text.Json.Serialization;
+
+namespace TelnyxSharp.Enums
+{
+    /// <summary>
+    /// Represents the categorisation of a comment on a Display Identity Record (DIR).
+    /// Customers post <see cref="CustomerInquiry"/>; the Telnyx team posts the remaining categories.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter<DirCommentType>))]
+    public enum DirCommentType
+    {
+        /// <summary>
+        /// A comment from the Telnyx vetting team about the vetting process.
+        /// </summary>
+        [JsonStringEnumMemberName("vetting_comment")]
+        VettingComment,
+
+        /// <summary>
+        /// A comment explaining why the DIR was rejected.
+        /// </summary>
+        [JsonStringEnumMemberName("rejection_reason")]
+        RejectionReason,
+
+        /// <summary>
+        /// An internal note. Filtered out of customer-visible responses.
+        /// </summary>
+        [JsonStringEnumMemberName("internal_note")]
+        InternalNote,
+
+        /// <summary>
+        /// A notification from the Telnyx team.
+        /// </summary>
+        [JsonStringEnumMemberName("notification")]
+        Notification,
+
+        /// <summary>
+        /// A status update from the Telnyx team.
+        /// </summary>
+        [JsonStringEnumMemberName("status_update")]
+        StatusUpdate,
+
+        /// <summary>
+        /// An inquiry posted by the customer.
+        /// </summary>
+        [JsonStringEnumMemberName("customer_inquiry")]
+        CustomerInquiry,
+
+        /// <summary>
+        /// A response from the Telnyx team to a customer inquiry.
+        /// </summary>
+        [JsonStringEnumMemberName("admin_response")]
+        AdminResponse
+    }
+}

--- a/TelnyxSharp/Enums/DirPhoneNumberStatus.cs
+++ b/TelnyxSharp/Enums/DirPhoneNumberStatus.cs
@@ -1,0 +1,54 @@
+using System.Text.Json.Serialization;
+
+namespace TelnyxSharp.Enums
+{
+    /// <summary>
+    /// Represents the lifecycle status of a phone number attached to a Display Identity Record (DIR)
+    /// in the Branded Calling API.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter<DirPhoneNumberStatus>))]
+    public enum DirPhoneNumberStatus
+    {
+        /// <summary>
+        /// The batch this number belongs to has been submitted for vetting.
+        /// </summary>
+        [JsonStringEnumMemberName("submitted")]
+        Submitted,
+
+        /// <summary>
+        /// Telnyx is reviewing the batch this number belongs to.
+        /// </summary>
+        [JsonStringEnumMemberName("in_review")]
+        InReview,
+
+        /// <summary>
+        /// Approved; the DIR's display identity will be shown on outbound calls from this number.
+        /// </summary>
+        [JsonStringEnumMemberName("verified")]
+        Verified,
+
+        /// <summary>
+        /// Telnyx rejected this submission; the customer may re-add the number to retry.
+        /// </summary>
+        [JsonStringEnumMemberName("unsuccessful")]
+        Unsuccessful,
+
+        /// <summary>
+        /// Temporarily disabled (e.g. by an active infringement claim on the DIR).
+        /// </summary>
+        [JsonStringEnumMemberName("suspended")]
+        Suspended,
+
+        /// <summary>
+        /// Verification expired; re-add the number to renew.
+        /// </summary>
+        [JsonStringEnumMemberName("expired")]
+        Expired,
+
+        /// <summary>
+        /// Terminal state; the number cannot be re-added on this or any other DIR the customer owns.
+        /// </summary>
+        [JsonStringEnumMemberName("permanently_rejected")]
+        PermanentlyRejected
+    }
+}

--- a/TelnyxSharp/Enums/DirStatus.cs
+++ b/TelnyxSharp/Enums/DirStatus.cs
@@ -1,0 +1,71 @@
+using System.Text.Json.Serialization;
+
+namespace TelnyxSharp.Enums
+{
+    /// <summary>
+    /// Represents the lifecycle status of a Display Identity Record (DIR) in the Branded Calling API.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter<DirStatus>))]
+    public enum DirStatus
+    {
+        /// <summary>
+        /// Newly created; editable; not yet submitted.
+        /// </summary>
+        [JsonStringEnumMemberName("draft")]
+        Draft,
+
+        /// <summary>
+        /// Submitted for vetting; Telnyx is reviewing.
+        /// </summary>
+        [JsonStringEnumMemberName("submitted")]
+        Submitted,
+
+        /// <summary>
+        /// Telnyx is actively reviewing the DIR.
+        /// </summary>
+        [JsonStringEnumMemberName("in_review")]
+        InReview,
+
+        /// <summary>
+        /// Approved; phone numbers may be attached.
+        /// </summary>
+        [JsonStringEnumMemberName("verified")]
+        Verified,
+
+        /// <summary>
+        /// Telnyx rejected this submission; rejection reasons are populated and the DIR can be edited and resubmitted.
+        /// </summary>
+        [JsonStringEnumMemberName("rejected")]
+        Rejected,
+
+        /// <summary>
+        /// A system-side error occurred during processing; the DIR can be edited and resubmitted.
+        /// </summary>
+        [JsonStringEnumMemberName("unsuccessful")]
+        Unsuccessful,
+
+        /// <summary>
+        /// Temporarily disabled (e.g. by an active infringement claim).
+        /// </summary>
+        [JsonStringEnumMemberName("suspended")]
+        Suspended,
+
+        /// <summary>
+        /// Verification expired; the DIR must be resubmitted.
+        /// </summary>
+        [JsonStringEnumMemberName("expired")]
+        Expired,
+
+        /// <summary>
+        /// A trademark/impersonation claim is open against this DIR.
+        /// </summary>
+        [JsonStringEnumMemberName("infringement_claimed")]
+        InfringementClaimed,
+
+        /// <summary>
+        /// Terminal state; the DIR cannot be resubmitted.
+        /// </summary>
+        [JsonStringEnumMemberName("permanently_rejected")]
+        PermanentlyRejected
+    }
+}

--- a/TelnyxSharp/Enums/InfringementClaimResolution.cs
+++ b/TelnyxSharp/Enums/InfringementClaimResolution.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Serialization;
+
+namespace TelnyxSharp.Enums
+{
+    /// <summary>
+    /// Represents the resolution of an infringement claim. Set only when the claim status is resolved.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter<InfringementClaimResolution>))]
+    public enum InfringementClaimResolution
+    {
+        /// <summary>
+        /// The claim was upheld against the DIR.
+        /// </summary>
+        [JsonStringEnumMemberName("upheld")]
+        Upheld,
+
+        /// <summary>
+        /// The claim was rejected.
+        /// </summary>
+        [JsonStringEnumMemberName("rejected")]
+        Rejected,
+
+        /// <summary>
+        /// The claim was resolved with modifications to the DIR.
+        /// </summary>
+        [JsonStringEnumMemberName("modified")]
+        Modified
+    }
+}

--- a/TelnyxSharp/Enums/InfringementClaimStatus.cs
+++ b/TelnyxSharp/Enums/InfringementClaimStatus.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Serialization;
+
+namespace TelnyxSharp.Enums
+{
+    /// <summary>
+    /// Represents the lifecycle status of an infringement claim filed against a Display Identity Record (DIR).
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter<InfringementClaimStatus>))]
+    public enum InfringementClaimStatus
+    {
+        /// <summary>
+        /// Newly filed; the DIR is auto-suspended.
+        /// </summary>
+        [JsonStringEnumMemberName("pending")]
+        Pending,
+
+        /// <summary>
+        /// Contest evidence has been submitted; awaiting Telnyx review.
+        /// </summary>
+        [JsonStringEnumMemberName("contested")]
+        Contested,
+
+        /// <summary>
+        /// Final state; the claim has been resolved.
+        /// </summary>
+        [JsonStringEnumMemberName("resolved")]
+        Resolved
+    }
+}

--- a/TelnyxSharp/Enums/InfringementClaimType.cs
+++ b/TelnyxSharp/Enums/InfringementClaimType.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+
+namespace TelnyxSharp.Enums
+{
+    /// <summary>
+    /// Represents the category of infringement being claimed against a Display Identity Record (DIR).
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter<InfringementClaimType>))]
+    public enum InfringementClaimType
+    {
+        /// <summary>
+        /// A trademark infringement claim.
+        /// </summary>
+        [JsonStringEnumMemberName("trademark")]
+        Trademark,
+
+        /// <summary>
+        /// A copyright infringement claim.
+        /// </summary>
+        [JsonStringEnumMemberName("copyright")]
+        Copyright
+    }
+}

--- a/TelnyxSharp/Enums/TosProductType.cs
+++ b/TelnyxSharp/Enums/TosProductType.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+
+namespace TelnyxSharp.Enums
+{
+    /// <summary>
+    /// Represents the Telnyx product a Terms of Service agreement applies to.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter<TosProductType>))]
+    public enum TosProductType
+    {
+        /// <summary>
+        /// The Branded Calling product.
+        /// </summary>
+        [JsonStringEnumMemberName("branded_calling")]
+        BrandedCalling,
+
+        /// <summary>
+        /// The Phone Number Reputation product.
+        /// </summary>
+        [JsonStringEnumMemberName("number_reputation")]
+        NumberReputation
+    }
+}

--- a/TelnyxSharp/TelnyxClient.cs
+++ b/TelnyxSharp/TelnyxClient.cs
@@ -2,6 +2,8 @@
 using Polly.RateLimit;
 using System.Net.Http.Headers;
 using TelnyxSharp.Base;
+using TelnyxSharp.BrandedCalling.Interfaces;
+using TelnyxSharp.BrandedCalling.Operations;
 using TelnyxSharp.DetailRecords.Interfaces;
 using TelnyxSharp.DetailRecords.Operations;
 using TelnyxSharp.Identity.Interfaces;
@@ -48,6 +50,7 @@ public class TelnyxClient : BaseOperations, ITelnyxClient
     private readonly Lazy<IDocumentsOperations> _documents;
     private readonly Lazy<IPortingOrderOperations> _portingOrder;
     private readonly Lazy<IDetailRecordsOperations> _detailRecordsSearch;
+    private readonly Lazy<IBrandedCallingOperations> _brandedCalling;
     private readonly Lazy<IV1ApiOperations> _v1Operations;
 
     // Public properties
@@ -65,6 +68,7 @@ public class TelnyxClient : BaseOperations, ITelnyxClient
     public IDocumentsOperations Documents => _documents.Value;
     public IPortingOrderOperations PortingOrder => _portingOrder.Value;
     public IDetailRecordsOperations DetailRecordsSearch => _detailRecordsSearch.Value;
+    public IBrandedCallingOperations BrandedCalling => _brandedCalling.Value;
     public IV1ApiOperations V1 => _v1Operations?.Value;
 
     public TelnyxClient(string? apiKey = null, string? v1ApiUser = null, string? v1ApiToken = null, bool debugMode = false, string? debugLogPath = null)
@@ -179,6 +183,10 @@ public class TelnyxClient : BaseOperations, ITelnyxClient
             new DetailRecordsOperations(Client, RateLimitRetryPolicy),
             LazyThreadSafetyMode.ExecutionAndPublication);
 
+        _brandedCalling = new Lazy<IBrandedCallingOperations>(() =>
+            new BrandedCallingOperations(Client, RateLimitRetryPolicy),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
         _v1Operations = new Lazy<IV1ApiOperations>(() =>
             {
                 if (_v1Client == null)
@@ -265,6 +273,10 @@ public class TelnyxClient : BaseOperations, ITelnyxClient
         if (_detailRecordsSearch.IsValueCreated && _detailRecordsSearch.Value is IDisposable disposableDetailRecordsSearch)
         {
             disposableDetailRecordsSearch.Dispose();
+        }
+        if (_brandedCalling.IsValueCreated && _brandedCalling.Value is IDisposable disposableBrandedCalling)
+        {
+            disposableBrandedCalling.Dispose();
         }
         if (_v1Operations.IsValueCreated && _v1Operations.Value is IDisposable disposableV1Operations)
         {

--- a/TelnyxSharp/TelnyxJsonSerializerContext.cs
+++ b/TelnyxSharp/TelnyxJsonSerializerContext.cs
@@ -1,5 +1,29 @@
 ﻿using System.Text.Json.Serialization;
 using TelnyxSharp.Base;
+using TelnyxSharp.BrandedCalling.Models;
+using TelnyxSharp.BrandedCalling.Models.Comments;
+using TelnyxSharp.BrandedCalling.Models.Comments.Requests;
+using TelnyxSharp.BrandedCalling.Models.Comments.Responses;
+using TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords;
+using TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Requests;
+using TelnyxSharp.BrandedCalling.Models.DisplayIdentityRecords.Responses;
+using TelnyxSharp.BrandedCalling.Models.Enterprises;
+using TelnyxSharp.BrandedCalling.Models.Enterprises.Requests;
+using TelnyxSharp.BrandedCalling.Models.Enterprises.Responses;
+using TelnyxSharp.BrandedCalling.Models.InfringementClaims;
+using TelnyxSharp.BrandedCalling.Models.InfringementClaims.Requests;
+using TelnyxSharp.BrandedCalling.Models.InfringementClaims.Responses;
+using TelnyxSharp.BrandedCalling.Models.PhoneNumberBatches;
+using TelnyxSharp.BrandedCalling.Models.PhoneNumberBatches.Requests;
+using TelnyxSharp.BrandedCalling.Models.PhoneNumberBatches.Responses;
+using TelnyxSharp.BrandedCalling.Models.PhoneNumbers;
+using TelnyxSharp.BrandedCalling.Models.PhoneNumbers.Requests;
+using TelnyxSharp.BrandedCalling.Models.PhoneNumbers.Responses;
+using TelnyxSharp.BrandedCalling.Models.ReferenceData;
+using TelnyxSharp.BrandedCalling.Models.ReferenceData.Requests;
+using TelnyxSharp.BrandedCalling.Models.ReferenceData.Responses;
+using TelnyxSharp.BrandedCalling.Models.TermsOfService;
+using TelnyxSharp.BrandedCalling.Models.TermsOfService.Responses;
 using TelnyxSharp.DetailRecords.Models.Requests;
 using TelnyxSharp.DetailRecords.Models.Responses;
 using TelnyxSharp.Enums;
@@ -1072,7 +1096,102 @@ namespace TelnyxSharp
 
     [JsonSerializable(typeof(RepublishPortingEventsResponse))]
 
+    // Branded Calling
+    [JsonSerializable(typeof(DirDocument))]
+    [JsonSerializable(typeof(RejectionReason))]
+
+    [JsonSerializable(typeof(Enterprise))]
+    [JsonSerializable(typeof(OrganizationContact))]
+    [JsonSerializable(typeof(BillingContact))]
+    [JsonSerializable(typeof(PhysicalAddress))]
+
+    [JsonSerializable(typeof(ListEnterprisesRequest))]
+    [JsonSerializable(typeof(ListEnterprisesResponse))]
+
+    [JsonSerializable(typeof(CreateEnterpriseRequest))]
+    [JsonSerializable(typeof(UpdateEnterpriseRequest))]
+    [JsonSerializable(typeof(EnterpriseResponse))]
+    [JsonSerializable(typeof(DeleteEnterpriseResponse))]
+
+    [JsonSerializable(typeof(Dir))]
+    [JsonSerializable(typeof(CallReason))]
+
+    [JsonSerializable(typeof(ListDirsRequest))]
+    [JsonSerializable(typeof(ListDirsResponse))]
+
+    [JsonSerializable(typeof(CreateDirRequest))]
+    [JsonSerializable(typeof(UpdateDirRequest))]
+    [JsonSerializable(typeof(DirResponse))]
+    [JsonSerializable(typeof(DeleteDirResponse))]
+
+    [JsonSerializable(typeof(RenderDirLoaRequest))]
+    [JsonSerializable(typeof(LoaAgent))]
+    [JsonSerializable(typeof(LoaSignature))]
+    [JsonSerializable(typeof(RenderDirLoaResponse))]
+
+    [JsonSerializable(typeof(DirPhoneNumber))]
+
+    [JsonSerializable(typeof(ListDirPhoneNumbersRequest))]
+    [JsonSerializable(typeof(ListDirPhoneNumbersResponse))]
+
+    [JsonSerializable(typeof(AddDirPhoneNumbersRequest))]
+    [JsonSerializable(typeof(AddDirPhoneNumbersResponse))]
+
+    [JsonSerializable(typeof(DeleteDirPhoneNumbersRequest))]
+    [JsonSerializable(typeof(DeleteDirPhoneNumbersResponse))]
+    [JsonSerializable(typeof(DeleteDirPhoneNumbersMeta))]
+    [JsonSerializable(typeof(DirPhoneNumberItemError))]
+
+    [JsonSerializable(typeof(DirPhoneNumberBatch))]
+
+    [JsonSerializable(typeof(ListDirPhoneNumberBatchesRequest))]
+    [JsonSerializable(typeof(ListDirPhoneNumberBatchesResponse))]
+    [JsonSerializable(typeof(DirPhoneNumberBatchResponse))]
+
+    [JsonSerializable(typeof(DirComment))]
+
+    [JsonSerializable(typeof(ListDirCommentsRequest))]
+    [JsonSerializable(typeof(ListDirCommentsResponse))]
+
+    [JsonSerializable(typeof(CreateDirCommentRequest))]
+    [JsonSerializable(typeof(DirCommentResponse))]
+
+    [JsonSerializable(typeof(InfringementClaim))]
+    [JsonSerializable(typeof(InfringementClaimDirRef))]
+    [JsonSerializable(typeof(ContestSubmission))]
+
+    [JsonSerializable(typeof(ListInfringementClaimsRequest))]
+    [JsonSerializable(typeof(ListInfringementClaimsResponse))]
+
+    [JsonSerializable(typeof(UpdateDirInfringementRequest))]
+    [JsonSerializable(typeof(ContestInfringementClaimRequest))]
+    [JsonSerializable(typeof(InfringementClaimResponse))]
+
+    [JsonSerializable(typeof(CallReasonReference))]
+    [JsonSerializable(typeof(DirDocumentTypeReference))]
+
+    [JsonSerializable(typeof(ListCallReasonsRequest))]
+    [JsonSerializable(typeof(ListCallReasonsResponse))]
+
+    [JsonSerializable(typeof(ValidateCallReasonsRequest))]
+    [JsonSerializable(typeof(ValidateCallReasonsResponse))]
+    [JsonSerializable(typeof(ValidateCallReasonsData))]
+
+    [JsonSerializable(typeof(ListDirDocumentTypesResponse))]
+
+    [JsonSerializable(typeof(TosAgreement))]
+    [JsonSerializable(typeof(TosAgreementResponse))]
+
+    [JsonSerializable(typeof(List<string>))]
+
     //Enums
+    [JsonSerializable(typeof(DirStatus))]
+    [JsonSerializable(typeof(DirPhoneNumberStatus))]
+    [JsonSerializable(typeof(DirCommentType))]
+    [JsonSerializable(typeof(InfringementClaimStatus))]
+    [JsonSerializable(typeof(InfringementClaimType))]
+    [JsonSerializable(typeof(InfringementClaimResolution))]
+    [JsonSerializable(typeof(TosProductType))]
     [JsonSerializable(typeof(PhoneNumberFeature))]
     [JsonSerializable(typeof(PortingOrderPermission))]
     [JsonSerializable(typeof(PortingOrderStatus))]


### PR DESCRIPTION
## Summary

Adds full **Branded Calling** API coverage to TelnyxSharp: all 27 operations across 8 tag groups (Enterprises, Display Identity Records, Phone Numbers, Phone Number Batches, Comments, Infringement Claims, Reference Data, Terms of Service), implemented over the existing HttpClient pipeline and exposed as a new lazy-loaded `BrandedCalling` section on `TelnyxClient`, mirroring the existing module pattern.

Out of scope (per issue): `/enterprises/{enterprise_id}/reputation*` endpoints (separate Telnyx Reputation Management product).

## Changes Made

### Models (`TelnyxSharp/BrandedCalling/Models/`)
- ~35 request/response schemas per the official Telnyx OpenAPI spec, organized per tag group with `Requests/`/`Responses/` folders matching the repo convention
- Shared component models: `DirDocument`, `RejectionReason`
- Lifecycle enums in `TelnyxSharp/Enums/`: `DirStatus`, `DirPhoneNumberStatus`, `DirCommentType`, `InfringementClaimStatus`, `InfringementClaimType`, `InfringementClaimResolution`, `TosProductType` (string-enum converters with `JsonStringEnumMemberName`)
- All serialized/deserialized types registered in the source-generated `TelnyxJsonSerializerContext`
- List responses reuse `PaginationMeta` so the existing auto-pagination in `BaseOperations.ExecuteAsync` applies; the bulk-delete response uses a custom meta carrying per-number errors

### Operations (`TelnyxSharp/BrandedCalling/Operations/`)
- `EnterpriseOperations` (6): list/create/retrieve/update/delete + `ActivateBrandedCalling`
- `DisplayIdentityRecordsOperations` (8): list (global + enterprise-scoped), create, retrieve, PATCH update, delete, submit, and `RenderLoa` — the LOA endpoint returns `application/pdf`, handled via a dedicated binary path (with 429 retry) exposing the PDF bytes on the response
- `DirPhoneNumberOperations` (3): list, bulk-add (batch semantics), bulk-delete (DELETE with JSON body, partial-success meta)
- `DirPhoneNumberBatchOperations` (2), `DirCommentOperations` (2), `InfringementClaimOperations` (4), `BrandedCallingReferenceOperations` (3 — incl. the bare-JSON-array body for `POST /call_reasons/validate`), `BrandedCallingTosOperations` (1)
- Umbrella `BrandedCallingOperations` with lazy sub-sections, wired into `TelnyxClient`/`ITelnyxClient`

### Tests (`TelnyxSharp.Tests/BrandedCallingOperationsTests.cs`)
- 21 TUnit tests over a mocked `HttpMessageHandler` (no API key needed): URL/method correctness, snake_case body serialization (incl. bare-array validation body, omitted nulls), enum round-tripping, 204 handling, per-number bulk-delete errors, LOA PDF bytes, and client wiring

## Testing Performed

- `dotnet build TelnyxSharp.sln` — green (0 errors)
- `dotnet test` — 106 total: 78 passed, 28 skipped (integration tests requiring `TELNYX_API_KEY`), 0 failed

## GitHub Issue
Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)